### PR TITLE
modplayer, globalnpc quick optimization

### DIFF
--- a/FargoPlayer.cs
+++ b/FargoPlayer.cs
@@ -828,7 +828,7 @@ namespace FargowiltasSouls
             }
 
             //full moon
-            if (Soulcheck.GetValue("Red Riding Super Bleed") && RedEnchant && ((proj.ranged && Main.moonPhase == 0) || (WillForce && Main.rand.Next(5) == 0)))
+            if (RedEnchant && Soulcheck.GetValue("Red Riding Super Bleed") && ((proj.ranged && Main.moonPhase == 0) || (WillForce && Main.rand.Next(5) == 0)))
             {
                 target.AddBuff(mod.BuffType("SuperBleed"), 240, true);
             }
@@ -911,7 +911,7 @@ namespace FargowiltasSouls
                 target.AddBuff(tikiDebuffs[Main.rand.Next(tikiDebuffs.Length)], 300);
             }
 
-            if (Soulcheck.GetValue("Red Riding Super Bleed") && RedEnchant && WillForce && Main.rand.Next(5) == 0)
+            if ((RedEnchant || WillForce) && Soulcheck.GetValue("Red Riding Super Bleed") && Main.rand.Next(5) == 0)
             {
                 target.AddBuff(mod.BuffType("SuperBleed"), 240, true);
             }
@@ -958,7 +958,7 @@ namespace FargowiltasSouls
 
         public override void OnHitNPCWithProj(Projectile proj, NPC target, int damage, float knockback, bool crit)
         {
-            if (CopperEnchant && Soulcheck.GetValue("Copper Lightning") && lightningCD == 0 && proj.type != ProjectileID.CultistBossLightningOrbArc && Array.IndexOf(wetProj, proj.type) == -1)
+            if (CopperEnchant && lightningCD == 0 && Soulcheck.GetValue("Copper Lightning") && proj.type != ProjectileID.CultistBossLightningOrbArc && Array.IndexOf(wetProj, proj.type) == -1)
             {
                 CopperEffect(target);
             }
@@ -974,7 +974,7 @@ namespace FargowiltasSouls
                 player.immune = false;
             }
 
-            if (NecroEnchant && Soulcheck.GetValue("Necro Guardian") && necroCD == 0 && (proj.ranged || ShadowForce || TerrariaSoul) && proj.type != mod.ProjectileType("DungeonGuardian"))
+            if (NecroEnchant && necroCD == 0 && Soulcheck.GetValue("Necro Guardian") && (proj.ranged || ShadowForce || TerrariaSoul) && proj.type != mod.ProjectileType("DungeonGuardian"))
             {
                 necroCD = 1200;
                 float screenX = Main.screenPosition.X;
@@ -1005,14 +1005,17 @@ namespace FargowiltasSouls
                 player.statMana += 5;
             }
 
-            if(Soulcheck.GetValue("Spectre Orbs"))
+            if ((SpiritForce || TerrariaSoul) && proj.type != ProjectileID.SpectreWrath)
             {
-                if ((SpiritForce || TerrariaSoul) && proj.type != ProjectileID.SpectreWrath)
+                if (Soulcheck.GetValue("Spectre Orbs"))
                 {
                     SpectreHeal(target, proj);
                     SpectreHurt(proj);
                 }
-                else if (SpectreEnchant && !SpiritForce && proj.magic)
+            }
+            else if (SpectreEnchant && !SpiritForce && proj.magic)
+            {
+                if (Soulcheck.GetValue("Spectre Orbs"))
                 {
                     if (crit)
                     {
@@ -1032,12 +1035,9 @@ namespace FargowiltasSouls
                         }
                     }
                 }
-
-                
             }
 
             
-
             if (TerrariaSoul)
             {
                 if (crit && TinCrit < 100)
@@ -1079,7 +1079,7 @@ namespace FargowiltasSouls
 
         public override void OnHitNPC(Item item, NPC target, int damage, float knockback, bool crit)
         {
-            if (CopperEnchant && Soulcheck.GetValue("Copper Lightning") && lightningCD == 0)
+            if (CopperEnchant && lightningCD == 0 && Soulcheck.GetValue("Copper Lightning"))
             {
                 CopperEffect(target);
             }

--- a/NPCs/FargoGlobalNPC.cs
+++ b/NPCs/FargoGlobalNPC.cs
@@ -282,8 +282,12 @@ namespace FargowiltasSouls.NPCs
                 {
                     if(npc.type == NPCID.SkeletronPrime)
                     {
+                        npc.defDefense = 9999;
+                        npc.defDamage = 1000;
                         npc.defense = 9999;
                         npc.damage = 1000;
+
+                        npc.ai[1] = 2f;
                     }
                 }
 
@@ -1608,6 +1612,11 @@ namespace FargowiltasSouls.NPCs
                     {
                         Main.PlaySound(15, (int)player.position.X, (int)player.position.Y, 0);
                         npc.life = 100;
+
+                        for (int k = 0; k < npc.buffImmune.Length; k++)
+                        {
+                            npc.buffImmune[k] = true;
+                        }
                     }
                     else if (npc.type == NPCID.RainbowSlime)
                     {

--- a/NPCs/FargoGlobalNPC.cs
+++ b/NPCs/FargoGlobalNPC.cs
@@ -1678,14 +1678,14 @@ namespace FargowiltasSouls.NPCs
                 damage = (int)(damage + npc.defense * .5);
             }
 
-            if (projectile.type == mod.ProjectileType("FishNuke"))
+            /*if (projectile.type == mod.ProjectileType("FishNuke"))
 			{
 				damage = npc.lifeMax / 10;
 				if(damage < 50)
 				{
 					damage = 50;
 				}
-			}			
+			}*/		
 		}
 
         public override void ModifyHitPlayer(NPC npc, Player target, ref int damage, ref bool crit)
@@ -2372,12 +2372,12 @@ namespace FargowiltasSouls.NPCs
             {
                 npc.knockBackResist += .1f;
             }
-            else
+            /*else
             {
                 NPC n = new NPC();
                 n.SetDefaults(npc.type);
                 npc.knockBackResist = n.knockBackResist;
-            }
+            }*/
         }
     }
 }

--- a/Projectiles/BossWeapons/FishNuke.cs
+++ b/Projectiles/BossWeapons/FishNuke.cs
@@ -1,3 +1,4 @@
+using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -20,6 +21,14 @@ namespace FargowiltasSouls.Projectiles.BossWeapons
 			projectile.timeLeft = 600;
 			aiType = ProjectileID.Bullet;
 		}
-		
-	}
+
+        public override void ModifyHitNPC(NPC target, ref int damage, ref float knockback, ref bool crit, ref int hitDirection)
+        {
+            damage = target.lifeMax / 10;
+            if (damage < 50)
+            {
+                damage = 50;
+            }
+        }
+    }
 }


### PR DESCRIPTION
switched around some checks in modplayer (i.e. checks bools before searching for strings)

npcs don't need to call setdefaults every damm time they get hit skreeeeeeeee

moved nuke fishron effect into its own class instead of being checked every time any projectile hits an enemy

masomode skeletron prime actually locks into dungeon guardian mode now, also made him become immune to all debuffs