### PR TITLE
:ech:

### DIFF
--- a/Buffs/Masomode/MarkedforDeath.cs
+++ b/Buffs/Masomode/MarkedforDeath.cs
@@ -1,32 +1,66 @@
 using Terraria;
 using Terraria.DataStructures;
 using Terraria.ModLoader;
+using Microsoft.Xna.Framework;
 
 namespace FargowiltasSouls.Buffs.Masomode
 {
-    public class MarkedforDeath : ModBuff
-    {
-        public override void SetDefaults()
-        {
-            DisplayName.SetDefault("Marked for Death");
-            Description.SetDefault("You will die when time runs out.");
-            Main.debuff[Type] = true;
+	public class MarkedforDeath : ModBuff
+	{
+		public override void SetDefaults()
+		{
+			DisplayName.SetDefault("Marked for Death");
+			Description.SetDefault("You will die when time runs out.");
+			Main.debuff[Type] = true;
             Main.pvpBuff[Type] = true;
             Main.buffNoSave[Type] = true;
             canBeCleared = true;
-        }
-
-        public override bool Autoload(ref string name, ref string texture)
+		}
+		
+		public override bool Autoload(ref string name, ref string texture)
         {
             texture = "FargowiltasSouls/Buffs/PlaceholderDebuff";
 
             return true;
         }
 
-        //note: deleting this buff (i.e. nurse) will remove it without killing the player
-        public override void Update(Player player, ref int buffIndex)
+		//note: clearing this buff (i.e. nurse) will remove it without killing the player
+		public override void Update(Player player, ref int buffIndex)
         {
-            if (player.buffTime[buffIndex] < 3) player.KillMe(PlayerDeathReason.ByCustomReason(player.name + " was reaped by the cold hand of death."), 4444, 0);
+			if (player.buffTime[buffIndex] < 3)
+			{
+                int damage = player.statLife - player.statLifeMax2 / 10;
+
+                if (damage > 0) //simulating basics of player.hurt()
+                {
+                    if (Main.netMode == 1)
+                        NetMessage.SendData(84, -1, -1, null, player.whoAmI);
+
+                    player.statLife = player.statLifeMax2 / 10;
+
+                    NetMessage.SendData(13, -1, -1, null, player.whoAmI);
+                    NetMessage.SendData(16, -1, -1, null, player.whoAmI);
+                    NetMessage.SendPlayerHurt(player.whoAmI, PlayerDeathReason.ByCustomReason(player.name + " was reaped by the cold hand of death."), damage, 0, false, false, -1, -1, -1);
+
+                    CombatText.NewText(new Rectangle((int)player.position.X, (int)player.position.Y, player.width, player.height), CombatText.DamagedFriendly, damage, false, false);
+
+                    player.immune = true;
+                    player.immuneTime = player.longInvince ? 80 : 40;
+
+                    player.lifeRegenTime = 0;
+
+                    if (player.Male)
+                        Main.PlaySound(1, (int)player.position.X, (int)player.position.Y, 1, 1f, 0.0f);
+                    else
+                        Main.PlaySound(20, (int)player.position.X, (int)player.position.Y, 1, 1f, 0.0f);
+                }
+                else
+                {
+                    player.KillMe(PlayerDeathReason.ByCustomReason(player.name + " was reaped by the cold hand of death."), 4444, 0);
+                }
+
+                player.DelBuff(buffIndex);
+            }
         }
 
         public override bool ReApply(Player player, int time, int buffIndex)


### PR DESCRIPTION
-moon lord's disgusting summons only trigger when his core is vulnerable
-moon lord's attacks will inflict literally any debuff from vanilla or masomode at random when his core is vulnerable, after killing moon lord 120 times they will inflict another debuff for every tick they touch the player
-nerfed brain suckler fire rate
-destroyer lasers also inflict very short clipped wings
-destroyer entire body inflicts lightning rod
-ML phantasmal deathray inflict marked for death, true eye beam inflict random debuffs
-ML debuff roulette only after core exposed
-ML replaces moon bite with mutant nibble, but only after core has been exposed (adjusted bite check)
-ML visions and dragons spawn on fixed timer, visions from hands, dragon from third eye
-marked for death reduces health to 10% when it activates, only instakill when you don't have enough health
-fixed krampus duplicating items if you held them with your mouse while touching him
-goblin thieves steal three random items on hit
-krampus also steals an armor piece on hit
-demon sickles inflict shadowflame
-srollers have triple health and double defense
-black recluse moves faster when target is webbed, also makes them defenseless for same duration as webbed
-clowns can spawn on any night