### PR TITLE
fixes and masomemes

### DIFF
--- a/FargoPlayer.cs
+++ b/FargoPlayer.cs
@@ -687,15 +687,12 @@ namespace FargowiltasSouls
                 multiplier *= .75f;
             }
 
-            if (TungstenEnchant)
+            if (TungstenEnchant && Soulcheck.GetValue("Tungsten Effect"))
             {
-                multiplier *= .125f;
-            }
-
-            if(Soulcheck.GetValue("Tungsten Effect") &&
-                TerraForce && !TerrariaSoul)
-            {
-                multiplier *= .33f;
+                if (TerraForce)
+                    multiplier *= .33f;
+                else if (!TerrariaSoul)
+                    multiplier *= .125f;
             }
 
             if (ObsidianEnchant)

--- a/Items/Accessories/Forces/ShadowForce.cs
+++ b/Items/Accessories/Forces/ShadowForce.cs
@@ -43,7 +43,7 @@ Summons a pet Black Cat, Baby Eater of Souls, Shadow Orb, Baby Skeletron Head, C
             modPlayer.NinjaEffect(hideVisual);
             modPlayer.ShadowEffect(hideVisual);
             modPlayer.NecroEffect(hideVisual);
-            modPlayer.SpookyEnchant = true;
+            modPlayer.SpookyEffect(hideVisual);
             modPlayer.ShinobiEffect(hideVisual);
             modPlayer.DarkArtistEffect(hideVisual);
         }

--- a/Items/Accessories/Forces/TerraForce.cs
+++ b/Items/Accessories/Forces/TerraForce.cs
@@ -18,8 +18,8 @@ If an enemy is wet, the chance and damage is increased
 Sets your critical strike chance to 10%
 Every crit will increase it by 5%
 Getting hit drops your crit back down
-Allows the player to dash into the enemy
 Right Click to guard with your shield
+Your shield will also protect you from projectiles
 You attract items from a much larger range and fall 5 times as quickly
 Attacks may inflict enemies with Lead Poisoning
 Your weapons shoot at 1/3 the speed

--- a/Items/Accessories/Souls/UniverseSoul.cs
+++ b/Items/Accessories/Souls/UniverseSoul.cs
@@ -56,7 +56,8 @@ All attacks inflict Flames of the Universe");
             player.counterWeight = 556 + Main.rand.Next(6);
             player.yoyoGlove = true;
             player.yoyoString = true;
-            player.scope = true;
+            if (Soulcheck.GetValue("Universe Scope"))
+                player.scope = true;
             player.manaFlower = true;
             player.manaMagnet = true;
             player.magicCuffs = true;

--- a/soulcheck.cs
+++ b/soulcheck.cs
@@ -74,6 +74,7 @@ namespace FargowiltasSouls
             #endregion
 
             ["Universe Speedup"] = new Color(81, 181, 113),
+            ["Universe Scope"] = new Color(81, 181, 113),
 
             ["Spore Sac"] = new Color(81, 181, 113),
             ["Super Speed"] = new Color(81, 181, 113),
@@ -98,6 +99,7 @@ namespace FargowiltasSouls
             ["Cursed Sapling Pet"] = new Color(81, 181, 113),
             ["Black Cat Pet"] = new Color(81, 181, 113),
             ["Seedling Pet"] = new Color(81, 181, 113),
+            ["Shadow Orb Pet"] = new Color(81, 181, 113),
             ["Crimson Heart Pet"] = new Color(81, 181, 113),
             ["Magic Lantern Pet"] = new Color(81, 181, 113),
             ["Truffle Pet"] = new Color(81, 181, 113),


### PR DESCRIPTION
-fixed terra force reducing use speed to 12.5% (should be 33%)
-fixed shadow enchant not giving a shadow orb light pet
-fixed shadow force not giving shadow orb or eyeball spring
-added soul of universe toggle for sniper scope effect
-paladins give all nearby enemies 50% DR
-twins become invincible in phase 3 until their partner is in phase 3
-twins gain 9999 defense and regenerate extremely fast when they both enter phase 3, stops when they're both fully healed
-phase 2 BOC has a chance to inflict very short confused every time it's hurt haHAAAAAA
-ice tortoise gains damage reduction as life decreases, maxes at 75% DR
-normal mimics have cross necklace and get at least 20 frames immune time on hit
-eater of worlds body has same pierce resistance as destroyer body