### PR TITLE
masobuffs LUL

### DIFF
--- a/Projectiles/FargoGlobalProjectile.cs
+++ b/Projectiles/FargoGlobalProjectile.cs
@@ -825,11 +825,7 @@ namespace FargowiltasSouls.Projectiles
                     case ProjectileID.SeedPlantera:
                         target.AddBuff(BuffID.Poisoned, Main.rand.Next(60, 300));
                         target.AddBuff(BuffID.Venom, Main.rand.Next(60, 300));
-
-                        if (target.HasBuff(mod.BuffType<Infested>()))
-                            target.AddBuff(mod.BuffType<Infested>(), Main.rand.Next(180, 360));
-                        else
-                            target.AddBuff(mod.BuffType<Infested>(), Main.rand.Next(90, 180));
+                        target.AddBuff(mod.BuffType<Infested>(), Main.rand.Next(180, 360));
                         break;
 
                     case ProjectileID.DesertDjinnCurse:
@@ -972,11 +968,7 @@ namespace FargowiltasSouls.Projectiles
                         {
                             target.AddBuff(BuffID.Poisoned, Main.rand.Next(60, 300));
                             target.AddBuff(BuffID.Venom, Main.rand.Next(60, 300));
-
-                            if (target.HasBuff(mod.BuffType<Infested>()))
-                                target.AddBuff(mod.BuffType<Infested>(), Main.rand.Next(180, 360));
-                            else
-                                target.AddBuff(mod.BuffType<Infested>(), Main.rand.Next(90, 180));
+                            target.AddBuff(mod.BuffType<Infested>(), Main.rand.Next(180, 360));
                         }
                         break;
 


### PR DESCRIPTION
-buffed golem body regen to 1000 again
-buffed plantera infested duration a LOT
-buffed plantera phase 2 defense
-plantera inflicts mutant nibble on touch
-plantera enrages when the player is infested; moves at 200% speed, fires twice as fast, gains tripled defense, and regeneration timer is lowered to 1sec
-increased clown hexed on touch to 20 seconds
-undead miners inflict obscenely long lethargic, darkness, blackout, and steal all your tools
-removed skeletron hand debug text
-fixed twins regenerating forever glitch (i think)