### PR TITLE
always more changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
 masomode stuff to test again.txt
+FargowiltasSouls.csproj
 
 # User-specific files
 *.suo

--- a/Buffs/Masomode/NullificationCurse.cs
+++ b/Buffs/Masomode/NullificationCurse.cs
@@ -1,0 +1,27 @@
+using Terraria;
+using Terraria.ModLoader;
+
+namespace FargowiltasSouls.Buffs.Masomode
+{
+    public class NullificationCurse : ModBuff
+    {
+        public override void SetDefaults()
+        {
+            DisplayName.SetDefault("Nullification Curse");
+            Description.SetDefault("Moon Lord is only vulnerable to one damage type!");
+            Main.debuff[Type] = true;
+            Main.pvpBuff[Type] = true;
+            Main.buffNoSave[Type] = true;
+            Main.buffNoTimeDisplay[Type] = true;
+            longerExpertDebuff = true;
+            canBeCleared = true;
+        }
+
+        public override bool Autoload(ref string name, ref string texture)
+        {
+            texture = "FargowiltasSouls/Buffs/PlaceholderDebuff";
+
+            return true;
+        }
+    }
+}

--- a/Buffs/Masomode/Sadism.cs
+++ b/Buffs/Masomode/Sadism.cs
@@ -8,7 +8,7 @@ namespace FargowiltasSouls.Buffs.Masomode
         public override void SetDefaults()
         {
             DisplayName.SetDefault("Sadism");
-            Description.SetDefault("Immune to all Masochist Mode debuffs");
+            Description.SetDefault("Immune to almost all Masochist Mode debuffs");
             Main.buffNoSave[Type] = false;
         }
 

--- a/FargoPlayer.cs
+++ b/FargoPlayer.cs
@@ -1543,11 +1543,11 @@ namespace FargowiltasSouls
                 Projectile[] projs = FargoGlobalProjectile.XWay(8, player.Center, mod.ProjectileType<SporeBoom>(), 5, (int)(dmg * player.magicDamage), 5f);
                 Projectile[] projs2 = FargoGlobalProjectile.XWay(8, player.Center, mod.ProjectileType<SporeBoom>(), 2.5f, 0, 0f);
 
-                for(int i = 0; i < projs.Length; i++)
+                /*for(int i = 0; i < projs.Length; i++)
                 {
                     projs[i].GetGlobalProjectile<FargoGlobalProjectile>().CanSplit = false;
                     projs2[i].GetGlobalProjectile<FargoGlobalProjectile>().CanSplit = false;
-                }
+                }*/
             }
 
             if(TinEnchant)

--- a/FargowiltasSouls.csproj
+++ b/FargowiltasSouls.csproj
@@ -34,6 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" Exclude="obj\**\*.*" />
+    <Compile Include="Buffs\Masomode\NullificationCurse.cs" />
     <Compile Include="Buffs\Masomode\Sadism.cs" />
     <Compile Include="Items\Misc\Sadism.cs" />
   </ItemGroup>

--- a/FargowiltasSouls.csproj
+++ b/FargowiltasSouls.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -34,9 +34,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" Exclude="obj\**\*.*" />
-    <Compile Include="Buffs\Masomode\NullificationCurse.cs" />
-    <Compile Include="Buffs\Masomode\Sadism.cs" />
-    <Compile Include="Items\Misc\Sadism.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Xna.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
@@ -59,15 +56,10 @@
     <Reference Include="Terraria">
       <HintPath>C:\Program Files (x86)\Steam\steamapps\common\terraria\Terraria.exe</HintPath>
     </Reference>
-    <Reference Include="Terrariamod">
-      <HintPath>..\..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Terraria\Terrariamod.exe</HintPath>
-    </Reference>
-    <Reference Include="ThoriumMod">
-      <HintPath>..\folder for wip\ThoriumMod.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>"C:\Program Files (x86)\Steam\steamapps\common\terraria\tModLoaderServer.exe" -build "$(ProjectDir)\" -eac "$(TargetPath)"</PostBuildEvent>
+   <PostBuildEvent>"C:\Program Files (x86)\Steam\steamapps\common\terraria\tModLoaderServer.exe" -build "$(ProjectDir)\" -eac "$(TargetPath)"</PostBuildEvent>
   </PropertyGroup>
 </Project>
+

--- a/Items/Accessories/Souls/DimensionSoul.cs
+++ b/Items/Accessories/Souls/DimensionSoul.cs
@@ -178,7 +178,7 @@ Effects of Frog Legs, Lava Waders, Angler Tackle Bag");
             //presserator
             player.autoActuator = true;
             //builder mode
-            if (!Soulcheck.GetValue("Builder Mode"))
+            if (Soulcheck.GetValue("Builder Mode"))
             {
                 modPlayer.BuilderMode = true;
             }

--- a/Items/Accessories/Souls/DimensionSoul.cs
+++ b/Items/Accessories/Souls/DimensionSoul.cs
@@ -117,12 +117,16 @@ Effects of Frog Legs, Lava Waders, Angler Tackle Bag");
             {
                 player.maxRunSpeed += 15f;
                 player.runAcceleration += .25f;
+                player.autoJump = true;
+                player.jumpSpeedBoost += 2.4f;
+                player.jumpBoost = true;
+                player.maxFallSpeed += 5f;
             }
-            else
+            /*else
             {
                 player.maxRunSpeed += 5f;
                 player.runAcceleration += .1f;
-            }
+            }*/
 
             player.moveSpeed += 0.5f;
             player.accRunSpeed = 12f;
@@ -137,11 +141,11 @@ Effects of Frog Legs, Lava Waders, Angler Tackle Bag");
             player.fireWalk = true;
             player.lavaImmune = true;
             //frog legs
-            player.autoJump = true;
-            player.jumpSpeedBoost += 2.4f;
-            player.jumpBoost = true;
+            //player.autoJump = true;
+            //player.jumpSpeedBoost += 2.4f;
+            //player.jumpBoost = true;
             //slime mount
-            player.maxFallSpeed += 5f;
+            //player.maxFallSpeed += 5f;
 
             //FLIGHT MASTERY
             player.wingTimeMax = 999999;

--- a/Items/Accessories/Souls/EternitySoul.cs
+++ b/Items/Accessories/Souls/EternitySoul.cs
@@ -153,12 +153,16 @@ and most of SoT not mentioned because meme tooltip length
             {
                 player.maxRunSpeed += 15f;
                 player.runAcceleration += .25f;
+                player.autoJump = true;
+                player.jumpSpeedBoost += 2.4f;
+                player.jumpBoost = true;
+                player.maxFallSpeed += 5f;
             }
-            else
+            /*else
             {
                 player.maxRunSpeed += 5f;
                 player.runAcceleration += .1f;
-            }
+            }*/
             player.moveSpeed += 0.5f;
             player.accRunSpeed = 12f;
             player.rocketBoots = 3;
@@ -172,11 +176,11 @@ and most of SoT not mentioned because meme tooltip length
             player.fireWalk = true;
             player.lavaImmune = true;
             //frog legs
-            player.autoJump = true;
-            player.jumpSpeedBoost += 2.4f;
-            player.jumpBoost = true;
+            //player.autoJump = true;
+            //player.jumpSpeedBoost += 2.4f;
+            //player.jumpBoost = true;
             //slime mount
-            player.maxFallSpeed += 5f;
+            //player.maxFallSpeed += 5f;
 
             //FLIGHT MASTERY
             player.wingTimeMax = 999999;

--- a/Items/Accessories/Souls/EternitySoul.cs
+++ b/Items/Accessories/Souls/EternitySoul.cs
@@ -213,7 +213,7 @@ and most of SoT not mentioned because meme tooltip length
             //presserator
             player.autoActuator = true;
             //builder mode
-            if (!Soulcheck.GetValue("Builder Mode"))
+            if (Soulcheck.GetValue("Builder Mode"))
             {
                 modPlayer.BuilderMode = true;
             }

--- a/Items/Accessories/Souls/SupersonicSoul.cs
+++ b/Items/Accessories/Souls/SupersonicSoul.cs
@@ -62,12 +62,16 @@ Grants immunity to lava and fall damage");
             {
                 player.maxRunSpeed += 10f;
                 player.runAcceleration += .25f;
+                player.autoJump = true;
+                player.jumpSpeedBoost += 2.4f;
+                player.maxFallSpeed += 5f;
+                player.jumpBoost = true;
             }
-            else
+            /*else
             {
                 player.maxRunSpeed += 5f;
                 player.runAcceleration += .1f;
-            }
+            }*/
 
             player.moveSpeed += 0.5f;
             player.rocketBoots = 3;
@@ -81,8 +85,8 @@ Grants immunity to lava and fall damage");
             player.fireWalk = true;
             player.lavaImmune = true;
             //frog legs
-            player.autoJump = true;
-            player.jumpSpeedBoost += 2.4f;
+            //player.autoJump = true;
+            //player.jumpSpeedBoost += 2.4f;
             player.noFallDmg = true;
             //bundle
             if(player.wingTime == 0)
@@ -91,9 +95,9 @@ Grants immunity to lava and fall damage");
                 player.doubleJumpSandstorm = true;
                 player.doubleJumpBlizzard = true;
             }
-            player.jumpBoost = true;
+            //player.jumpBoost = true;
             //slime mount
-            player.maxFallSpeed += 5f;
+            //player.maxFallSpeed += 5f;
         }
 
         public override void AddRecipes()

--- a/Items/Accessories/Souls/WorldShaperSoul.cs
+++ b/Items/Accessories/Souls/WorldShaperSoul.cs
@@ -23,7 +23,8 @@ Auto paint and actuator effect
 Provides light 
 Grants the ability to enable Builder Mode:
 Anything that creates a tile will not be consumed 
-No enemies can spawn");
+No enemies can spawn
+Effect can be disabled in Soul Toggles menu");
         }
 
         public override void SetDefaults()
@@ -54,7 +55,7 @@ No enemies can spawn");
             //presserator
             player.autoActuator = true;
 
-            if (!Soulcheck.GetValue("Builder Mode"))
+            if (Soulcheck.GetValue("Builder Mode"))
             {
                 modPlayer.BuilderMode = true;
             }

--- a/Items/Misc/Sadism.cs
+++ b/Items/Misc/Sadism.cs
@@ -14,7 +14,7 @@ namespace FargowiltasSouls.Items.Misc
         public override void SetStaticDefaults()
 		{
 			DisplayName.SetDefault("Sadism");
-            Tooltip.SetDefault( "Grants immunity to all Masochist Mode debuffs");
+            Tooltip.SetDefault( "Grants immunity to almost all Masochist Mode debuffs");
 		}
 
 		public override void SetDefaults()

--- a/NPCs/FargoGlobalNPC.cs
+++ b/NPCs/FargoGlobalNPC.cs
@@ -2590,24 +2590,50 @@ namespace FargowiltasSouls.NPCs
                             {
                                 masoBool[0] = false;
 
-                                Vector2 spawnPos = new Vector2(npc.position.X - npc.width * 7, npc.Center.Y);
-                                
-                                for (int i = 0; i < 6; i++)
+                                Vector2 spawnPos = new Vector2(npc.position.X, npc.Center.Y);
+
+                                if (Main.tile[(int)npc.Center.X / 16, (int)npc.Center.Y / 16] != null && //in temple
+                                    Main.tile[(int)npc.Center.X / 16, (int)npc.Center.Y / 16].wall == WallID.LihzahrdBrickUnsafe)
                                 {
-                                    int tilePosX = (int)spawnPos.X / 16 + npc.width * i * 3 / 16;
-					                int tilePosY = (int)spawnPos.Y / 16;// + 1;
+                                    spawnPos.X -= npc.width * 2;
+                                    for (int i = 0; i < 2; i++)
+                                    {
+                                        int tilePosX = (int)spawnPos.X / 16 + npc.width * i * 5 / 16;
+                                        int tilePosY = (int)spawnPos.Y / 16;// + 1;
 
-                                    if (Main.tile[tilePosX, tilePosY] == null)
-						            Main.tile[tilePosX, tilePosY] = new Tile();
+                                        if (Main.tile[tilePosX, tilePosY] == null)
+                                            Main.tile[tilePosX, tilePosY] = new Tile();
 
-					                while (!(Main.tile[tilePosX, tilePosY].nactive() && Main.tileSolid[(int)Main.tile[tilePosX, tilePosY].type]))
-					                {
-						                tilePosY++;
-						                if (Main.tile[tilePosX, tilePosY] == null)
-							                Main.tile[tilePosX, tilePosY] = new Tile();
-					                }
+                                        while (!(Main.tile[tilePosX, tilePosY].nactive() && Main.tileSolid[(int)Main.tile[tilePosX, tilePosY].type]))
+                                        {
+                                            tilePosY++;
+                                            if (Main.tile[tilePosX, tilePosY] == null)
+                                                Main.tile[tilePosX, tilePosY] = new Tile();
+                                        }
 
-                                    Projectile.NewProjectile(tilePosX * 16 + 8, tilePosY * 16 + 8, 0f, -8f, ProjectileID.GeyserTrap, npc.damage / 6, 0f, Main.myPlayer);
+                                        Projectile.NewProjectile(tilePosX * 16 + 8, tilePosY * 16 + 8, 0f, -8f, ProjectileID.GeyserTrap, npc.damage / 6, 0f, Main.myPlayer);
+                                    }
+                                }
+                                else //outside temple
+                                {
+                                    spawnPos.X -= npc.width * 7;
+                                    for (int i = 0; i < 6; i++)
+                                    {
+                                        int tilePosX = (int)spawnPos.X / 16 + npc.width * i * 3 / 16;
+                                        int tilePosY = (int)spawnPos.Y / 16;// + 1;
+
+                                        if (Main.tile[tilePosX, tilePosY] == null)
+                                            Main.tile[tilePosX, tilePosY] = new Tile();
+
+                                        while (!(Main.tile[tilePosX, tilePosY].nactive() && Main.tileSolid[(int)Main.tile[tilePosX, tilePosY].type]))
+                                        {
+                                            tilePosY++;
+                                            if (Main.tile[tilePosX, tilePosY] == null)
+                                                Main.tile[tilePosX, tilePosY] = new Tile();
+                                        }
+
+                                        Projectile.NewProjectile(tilePosX * 16 + 8, tilePosY * 16 + 8, 0f, -8f, ProjectileID.GeyserTrap, npc.damage / 5, 0f, Main.myPlayer);
+                                    }
                                 }
                             }
                         }
@@ -4838,7 +4864,7 @@ namespace FargowiltasSouls.NPCs
                     {
                         if (NPC.downedMechBossAny)
                         {
-                            if (spawnInfo.player.ZoneDungeon && night && normalSpawn)
+                            if (dungeon && night && normalSpawn)
                             {
                                 pool[NPCID.SkeletronHead] = BossIsAlive(ref skeleBoss, NPCID.SkeletronHead) ? .00125f : .0025f;
                             }
@@ -4871,9 +4897,19 @@ namespace FargowiltasSouls.NPCs
                             pool[NPCID.RaggedCaster] = .004f;
                             pool[NPCID.RaggedCasterOpenCoat] = .004f;
                         }
+
+                        if (NPC.downedAncientCultist && dungeon && !BossIsAlive(ref cultBoss, NPCID.CultistBoss))
+                        {
+                            pool[NPCID.CultistBoss] = 0.001f;
+                        }
                     }
                     else if (underworld)
                     {
+                        if (Main.hardMode && !BossIsAlive(ref wallBoss, NPCID.WallofFlesh))
+                        {
+                            pool[NPCID.WallofFlesh] = .005f;
+                        }
+
                         if (NPC.downedPlantBoss)
                         {
                             pool[NPCID.DiabolistRed] = .004f;
@@ -4908,6 +4944,10 @@ namespace FargowiltasSouls.NPCs
                                 pool[NPCID.VortexHornetQueen] = .01f;
                                 pool[NPCID.NebulaBrain] = .01f;
                                 pool[NPCID.StardustJellyfishBig] = .01f;
+                            }
+                            if (NPC.downedMoonlord && !BossIsAlive(ref moonBoss, NPCID.MoonLordCore))
+                            {
+                                pool[NPCID.MoonLordCore] = 0.001f;
                             }
                         }
                     }
@@ -6719,7 +6759,8 @@ namespace FargowiltasSouls.NPCs
 
                     case NPCID.GolemFistLeft:
                     case NPCID.GolemFistRight:
-                        target.AddBuff(mod.BuffType<Defenseless>(), Main.rand.Next(60, 300));
+                        target.AddBuff(mod.BuffType<Defenseless>(), Main.rand.Next(300, 600));
+                        target.AddBuff(BuffID.BrokenArmor, Main.rand.Next(60, 300));
                         break;
 
                     case NPCID.DD2Betsy:

--- a/NPCs/FargoGlobalNPC.cs
+++ b/NPCs/FargoGlobalNPC.cs
@@ -2392,6 +2392,8 @@ namespace FargowiltasSouls.NPCs
                         }
                         else
                         {
+                            Counter++; //phases transition twice as fast when core is exposed
+
                             int t = npc.HasPlayerTarget ? npc.target : npc.FindClosestPlayer();
                             if (t != -1)
                             {
@@ -3943,13 +3945,15 @@ namespace FargowiltasSouls.NPCs
 
                     case 80: //all moon lord parts
                         Counter++;
-                        if (Counter > 1200)
+                        if (Counter > 1800)
                         {
                             Counter = 0;
                             masoState++;
                             if (masoState > 4)
                                 masoState = 0;
                         }
+                        if (npc.type != NPCID.MoonLordCore)
+                            RegenTimer = 2;
                         break;
 
                     case 81: //ancient light when moon lord is alive
@@ -5880,6 +5884,8 @@ namespace FargowiltasSouls.NPCs
                         break;
 
                     case 12: //moon lord
+                        if (projectile.type == ProjectileID.PhantasmArrow || projectile.type == ProjectileID.CrystalShard)
+                            damage = 1;
                         /*switch (masoState)
                         {
                             case 0: if (!projectile.melee) damage = 0; break;

--- a/NPCs/FargoGlobalNPC.cs
+++ b/NPCs/FargoGlobalNPC.cs
@@ -2385,6 +2385,8 @@ namespace FargowiltasSouls.NPCs
 
                     case 38: //moon lord core
                         moonBoss = npc.whoAmI;
+                        if (Main.player[Main.myPlayer].active)
+                            Main.player[Main.myPlayer].AddBuff(mod.BuffType<NullificationCurse>(), 2);
 
                         if (!masoBool[0])
                         {

--- a/Projectiles/FargoGlobalProjectile.cs
+++ b/Projectiles/FargoGlobalProjectile.cs
@@ -923,15 +923,14 @@ namespace FargowiltasSouls.Projectiles
                         }
                         break;
 
-                    /*case ProjectileID.PhantasmalBolt:   //if ML alive, ML vulnerable
+                    case ProjectileID.PhantasmalBolt:   //if ML alive, ML vulnerable
                     case ProjectileID.PhantasmalEye:    //debuff once per hit normally
                     case ProjectileID.PhantasmalSphere: //debuff per tick while overlapping player if 120 MLs killed
-                        if (FargoGlobalNPC.BossIsAlive(ref FargoGlobalNPC.moonBoss, NPCID.MoonLordCore) && !Main.npc[FargoGlobalNPC.moonBoss].dontTakeDamage && (target.hurtCooldowns[1] == 0 || FargoWorld.MoonlordCount >= 120))
+                        if (FargoGlobalNPC.BossIsAlive(ref FargoGlobalNPC.moonBoss, NPCID.MoonLordCore) && !Main.npc[FargoGlobalNPC.moonBoss].dontTakeDamage && target.hurtCooldowns[1] == 0)
                         {
-                            int d = Main.rand.Next(Fargowiltas.DebuffIDs.Length);
-                            target.AddBuff(Fargowiltas.DebuffIDs[d], Main.rand.Next(60, 600));
+                            target.AddBuff(mod.BuffType<FlamesoftheUniverse>(), Main.rand.Next(15, 31));
                         }
-                        break;*/
+                        break;
 
                     case ProjectileID.MeteorShot:
                         if (masoProj)

--- a/Projectiles/FargoGlobalProjectile.cs
+++ b/Projectiles/FargoGlobalProjectile.cs
@@ -983,10 +983,18 @@ namespace FargowiltasSouls.Projectiles
                         break;
 
                     case ProjectileID.FlamesTrap:
+                    case ProjectileID.GeyserTrap:
                         if (FargoGlobalNPC.BossIsAlive(ref FargoGlobalNPC.primeBoss, NPCID.SkeletronPrime))
                             target.AddBuff(BuffID.OnFire, Main.rand.Next(60, 600));
                         else if (NPC.golemBoss != -1 && Main.npc[NPC.golemBoss].active && Main.npc[NPC.golemBoss].type == NPCID.Golem)
-                            target.AddBuff(BuffID.Burning, Main.rand.Next(60, 300));
+                        {
+                            if (Main.tile[(int)Main.npc[NPC.golemBoss].Center.X / 16, (int)Main.npc[NPC.golemBoss].Center.Y / 16] == null || //outside temple
+                                Main.tile[(int)Main.npc[NPC.golemBoss].Center.X / 16, (int)Main.npc[NPC.golemBoss].Center.Y / 16].wall != WallID.LihzahrdBrickUnsafe)
+                            {
+                                target.AddBuff(BuffID.OnFire, Main.rand.Next(60, 600));
+                                target.AddBuff(BuffID.Burning, Main.rand.Next(60, 300));
+                            }
+                        }
                         break;
 
                     case ProjectileID.SpikyBallTrap:

--- a/masomode stuff to test again.txt
+++ b/masomode stuff to test again.txt
@@ -13,7 +13,12 @@ ai notes: skeleton archer and friends
 //	default damage = 35
 //	default expertmode damage: *= 0.8
 
--spending >10sec completely above golem enrages him. 
+-spending >10sec completely above golem enrages him.
+-moon lord segments no longer have regeneration (the core still does)
+-did a thing to make jungle enchant not glitch
+-moon lord's original attacks inflict flames of the universe in phase 2
+-moon lord is immune to phantasm secondary arrows
+-made moon lord vulnerability phases longer in phase 1, but change twice as fast in phase 2
 
 -moon lord has attacks corresponding to each vulnerability except throwing in phase 2
 -ancient light is immune to inferno potion

--- a/masomode stuff to test again.txt
+++ b/masomode stuff to test again.txt
@@ -13,6 +13,11 @@ ai notes: skeleton archer and friends
 //	default damage = 35
 //	default expertmode damage: *= 0.8
 
+-buffed duration of golem fist defenseless
+-golem fist inflicts broken armor too
+-golem geysers/flamethrowers are nerfed in the temple (less geyser damage, neither inflict burning)
+-moon lord, lunatic cultist, wof can all natural spawn
+
 -spending >10sec completely above golem enrages him.
 -moon lord segments no longer have regeneration (the core still does)
 -did a thing to make jungle enchant not glitch

--- a/soulcheck.cs
+++ b/soulcheck.cs
@@ -73,7 +73,7 @@ namespace FargowiltasSouls
             #region soul toggles
             ["Melee Speed"] = new Color(81, 181, 113),
             ["Spore Sac"] = new Color(81, 181, 113),
-            ["No Builder Mode"] = new Color(81, 181, 113),
+            ["Builder Mode"] = new Color(81, 181, 113),
             ["Universe Speedup"] = new Color(81, 181, 113),
             ["Universe Scope"] = new Color(81, 181, 113),
             ["Supersonic Speed Boosts"] = new Color(81, 181, 113),


### PR DESCRIPTION
-spending >10sec completely above golem enrages him like king slime
-moon lord segments no longer have regeneration (the core still does)
-did a thing to make jungle enchant not glitch
-moon lord's original attacks inflict flames of the universe in phase 2
-moon lord is immune to phantasm secondary arrows
-made moon lord vulnerability phases longer in phase 1, but change twice as fast in phase 2
-debuff added to clarify moon lord gimmick
-nerfed supersonic speed skreeeeee
-fixed builder mode meme
-buffed duration of golem fist defenseless
-golem fist inflicts broken armor too
-golem geysers/flamethrowers are nerfed in the temple (less geyser damage, neither inflict burning)
-moon lord, lunatic cultist, wof can all natural spawn