### PR TITLE
-fishron EX stats don't benefit from fishrons killed until fishron EX…

### DIFF
--- a/FargoPlayer.cs
+++ b/FargoPlayer.cs
@@ -1085,8 +1085,6 @@ namespace FargowiltasSouls
             {
                 player.statDefense -= 60;
                 player.endurance = 0;
-                player.longInvince = false;
-                player.noKnockback = false;
 
                 if (MaxLifeReduction > player.statLifeMax2 - 100)
                     MaxLifeReduction = player.statLifeMax2 - 100;

--- a/FargoWorld.cs
+++ b/FargoWorld.cs
@@ -16,6 +16,7 @@ namespace FargowiltasSouls
 
         //masomode
         public static bool MasochistMode;
+        public static bool downedFishronEX;
         public static int EyeCount;
         public static int SlimeCount;
         public static int EaterCount;
@@ -40,6 +41,7 @@ namespace FargowiltasSouls
 
             //masomode
             MasochistMode = false;
+            downedFishronEX = false;
             EyeCount = 0;
             SlimeCount = 0;
             EaterCount = 0;
@@ -82,6 +84,7 @@ namespace FargowiltasSouls
             if (_downedBetsy) downed.Add("betsy");
             if (_downedBoss) downed.Add("boss");
             if (MasochistMode) downed.Add("masochist");
+            if (downedFishronEX) downed.Add("downedFishronEX");
 
             return new TagCompound
             {
@@ -115,6 +118,7 @@ namespace FargowiltasSouls
             _downedBetsy = downed.Contains("betsy");
             _downedBoss = downed.Contains("boss");
             MasochistMode = downed.Contains("masochist");
+            downedFishronEX = downed.Contains("downedFishronEX");
         }
 
         public override void NetReceive(BinaryReader reader)
@@ -139,6 +143,7 @@ namespace FargowiltasSouls
             _downedBetsy = flags[0];
             _downedBoss = flags[1];
             MasochistMode = flags[2];
+            downedFishronEX = flags[3];
         }
 
         public override void NetSend(BinaryWriter writer)
@@ -163,9 +168,9 @@ namespace FargowiltasSouls
             {
                 [0] = _downedBetsy,
                 [1] = _downedBoss,
-                [2] = MasochistMode
+                [2] = MasochistMode,
+                [3] = downedFishronEX
             };
-
 
             writer.Write(flags);
         }

--- a/Items/Accessories/Masomode/DubiousCircuitry.cs
+++ b/Items/Accessories/Masomode/DubiousCircuitry.cs
@@ -12,7 +12,7 @@ namespace FargowiltasSouls.Items.Accessories.Masomode
         {
             DisplayName.SetDefault("Dubious Circuitry");
             Tooltip.SetDefault(@"'Malware probably not included'
-Grants immunity to Cursed Inferno, Ichor, Electrified, Lightning Rod, Defenseless, and Stunned
+Grants immunity to Cursed Inferno, Ichor, Electrified, Lightning Rod, Defenseless, Stunned, and knockback
 Your attacks inflict Cursed Inferno and Ichor
 Your attacks have a small chance to inflict Electrified and Lightning Rod
 Two friendly probes fight by your side
@@ -43,6 +43,7 @@ Reduces damage taken by 6%");
             if (Soulcheck.GetValue("Probes Minion"))
                 player.AddBuff(mod.BuffType("Probes"), 2);
             player.endurance += 0.06f;
+            player.noKnockback = true;
         }
 
         public override void AddRecipes()

--- a/Items/Accessories/Masomode/ReinforcedPlating.cs
+++ b/Items/Accessories/Masomode/ReinforcedPlating.cs
@@ -12,7 +12,7 @@ namespace FargowiltasSouls.Items.Accessories.Masomode
         {
             DisplayName.SetDefault("Reinforced Plating");
             Tooltip.SetDefault(@"'The sturdiest piece of a defeated foe'
-Grants immunity to Defenseless and Stunned
+Grants immunity to Defenseless, Stunned, and knockback
 Reduces damage taken by 10%");
         }
 
@@ -31,6 +31,7 @@ Reduces damage taken by 10%");
             player.buffImmune[mod.BuffType("Defenseless")] = true;
             player.buffImmune[mod.BuffType("Stunned")] = true;
             player.endurance += 0.1f;
+            player.noKnockback = true;
         }
     }
 }

--- a/Items/Accessories/Souls/MasochistSoul.cs
+++ b/Items/Accessories/Souls/MasochistSoul.cs
@@ -124,6 +124,7 @@ Allows the holder to control gravity");
             if (Soulcheck.GetValue("Probes Minion"))
                 player.AddBuff(mod.BuffType("Probes"), 2);
             player.endurance += 0.15f;
+            player.noKnockback = true;
 
             //magical bulb
             player.buffImmune[BuffID.Venom] = true;

--- a/Items/TruffleWormEX.cs
+++ b/Items/TruffleWormEX.cs
@@ -69,6 +69,7 @@ namespace FargowiltasSouls.Items
             ModRecipe recipe = new ModRecipe(mod);
 
             recipe.AddIngredient(ItemID.TruffleWorm);
+            recipe.AddIngredient(ItemID.ShrimpyTruffle);
             recipe.AddIngredient(mod.ItemType("LunarCrystal"), 5);
 
             recipe.AddTile(mod.TileType("CrucibleCosmosSheet"));

--- a/NPCs/DetonatingBubble.cs
+++ b/NPCs/DetonatingBubble.cs
@@ -38,6 +38,8 @@ namespace FargowiltasSouls.NPCs
         {
             npc.damage = (int)(npc.damage * 0.75);
             npc.lifeMax = 1;
+            if (FargoWorld.downedFishronEX || !FargoGlobalNPC.BossIsAlive(ref FargoGlobalNPC.fishBossEX, NPCID.DukeFishron))
+                npc.damage = (int)(npc.damage * (1 + FargoWorld.FishronCount * .0125));
         }
 
         public override void AI()

--- a/NPCs/DetonatingBubbleEX.cs
+++ b/NPCs/DetonatingBubbleEX.cs
@@ -35,6 +35,15 @@ namespace FargowiltasSouls.NPCs
             npc.GetGlobalNPC<FargoGlobalNPC>().ValhallaImmune = true;
         }
 
+        public override void ScaleExpertStats(int numPlayers, float bossLifeScale)
+        {
+            if (FargoWorld.downedFishronEX || !FargoGlobalNPC.BossIsAlive(ref FargoGlobalNPC.fishBossEX, NPCID.DukeFishron))
+            {
+                npc.lifeMax = (int)(npc.lifeMax * (1 + FargoWorld.FishronCount * .025));
+                npc.damage = (int)(npc.damage * (1 + FargoWorld.FishronCount * .0125));
+            }
+        }
+
         public override void AI()
         {
             if (npc.buffTime[0] != 0)

--- a/NPCs/FargoGlobalNPC.cs
+++ b/NPCs/FargoGlobalNPC.cs
@@ -277,6 +277,10 @@ namespace FargowiltasSouls.NPCs
                         npc.lifeMax *= 2;
                         break;
 
+                    case NPCID.AncientDoom:
+                        npc.damage *= 3;
+                        break;
+
                     default:
                         break;
                 }
@@ -1096,8 +1100,23 @@ namespace FargowiltasSouls.NPCs
 
 
                     case NPCID.DukeFishron:
-                        npc.lifeMax = (int)(npc.lifeMax * (1 + FargoWorld.FishronCount * .025));
-                        npc.damage = (int)(npc.damage * (1 + FargoWorld.FishronCount * .0125));
+                        if (FargoWorld.downedFishronEX || !spawnFishronEX)
+                        {
+                            npc.lifeMax = (int)(npc.lifeMax * (1 + FargoWorld.FishronCount * .025));
+                            npc.damage = (int)(npc.damage * (1 + FargoWorld.FishronCount * .0125));
+                        }
+                        break;
+                    case NPCID.Sharkron:
+                    case NPCID.Sharkron2:
+                        if (FargoWorld.downedFishronEX || !BossIsAlive(ref fishBossEX, NPCID.DukeFishron))
+                        {
+                            npc.lifeMax = (int)(npc.lifeMax * (1 + FargoWorld.FishronCount * .025));
+                            npc.damage = (int)(npc.damage * (1 + FargoWorld.FishronCount * .0125));
+                        }
+                        break;
+                    case NPCID.DetonatingBubble:
+                        if (FargoWorld.downedFishronEX || !BossIsAlive(ref fishBossEX, NPCID.DukeFishron))
+                            npc.damage = (int)(npc.damage * (1 + FargoWorld.FishronCount * .0125));
                         break;
 
 
@@ -5374,14 +5393,6 @@ namespace FargowiltasSouls.NPCs
                             }
                             break;
 
-                        case NPCID.TheHungryII:
-                            if (!BossIsAlive(ref wallBoss, NPCID.WallofFlesh))
-                            {
-                                NPC.SpawnWOF(target.Center);
-                                Main.PlaySound(15, (int)npc.position.X, (int)npc.position.Y, 0);
-                            }
-                            break;
-
                         case NPCID.Probe:
                             if (!BossIsAlive(ref destroyBoss, NPCID.TheDestroyer) && !BossIsAlive(ref primeBoss, NPCID.SkeletronPrime) && !BossIsAlive(ref spazBoss, NPCID.Spazmatism) && !BossIsAlive(ref retiBoss, NPCID.Retinazer))
                             {
@@ -5403,9 +5414,320 @@ namespace FargowiltasSouls.NPCs
                             }
                             break;
 
+                        case NPCID.BlueSlime:
+                            switch (npc.netID)
+                            {
+                                case NPCID.BlackSlime:
+                                    target.AddBuff(BuffID.Slimed, Main.rand.Next(30, 300));
+                                    target.AddBuff(BuffID.Darkness, Main.rand.Next(120, 1200));
+                                    break;
+
+                                case NPCID.BabySlime:
+                                    target.AddBuff(BuffID.Slimed, Main.rand.Next(240));
+                                    break;
+
+                                case NPCID.Pinky:
+                                    target.AddBuff(BuffID.Slimed, Main.rand.Next(300, 600));
+                                    target.AddBuff(mod.BuffType("Stunned"), Main.rand.Next(120));
+                                    break;
+
+                                default:
+                                    target.AddBuff(BuffID.Slimed, Main.rand.Next(30, 300));
+                                    break;
+                            }
+                            break;
+
+                        case NPCID.SpikedIceSlime:
+                            target.AddBuff(BuffID.Slimed, Main.rand.Next(30, 300));
+                            target.AddBuff(BuffID.Frostburn, Main.rand.Next(60, 300));
+                            break;
+
+                        case NPCID.SpikedJungleSlime:
+                            target.AddBuff(BuffID.Slimed, Main.rand.Next(30, 300));
+                            target.AddBuff(BuffID.Venom, Main.rand.Next(60, 300));
+                            break;
+
+                        case NPCID.MotherSlime:
+                            target.AddBuff(BuffID.Slimed, Main.rand.Next(30, 300));
+                            target.AddBuff(mod.BuffType("Antisocial"), Main.rand.Next(180, 1800));
+                            break;
+
+                        case NPCID.LavaSlime:
+                            target.AddBuff(BuffID.Oiled, Main.rand.Next(900, 1800));
+                            target.AddBuff(BuffID.OnFire, Main.rand.Next(120, 600));
+                            break;
+
+                        case NPCID.DungeonSlime:
+                            target.AddBuff(BuffID.Slimed, Main.rand.Next(30, 300));
+                            target.AddBuff(BuffID.Blackout, Main.rand.Next(120, 1200));
+                            break;
+
+                        case NPCID.KingSlime:
+                            target.AddBuff(BuffID.Slimed, Main.rand.Next(60, 600));
+                            target.AddBuff(mod.BuffType("ClippedWings"), Main.rand.Next(300, 600));
+
+                            if (Main.rand.Next(5) == 0 && !target.HasBuff(mod.BuffType("Stunned")))
+                                target.AddBuff(mod.BuffType("Stunned"), Main.rand.Next(30, 120));
+                            break;
+
+                        case NPCID.ToxicSludge:
+                            target.AddBuff(BuffID.Slimed, Main.rand.Next(60, 600));
+                            target.AddBuff(mod.BuffType("Infested"), Main.rand.Next(300, 600));
+                            break;
+
+                        case NPCID.CorruptSlime:
+                            target.AddBuff(BuffID.Slimed, Main.rand.Next(60, 600));
+                            target.AddBuff(mod.BuffType("Rotting"), Main.rand.Next(300, 1200));
+                            break;
+
+                        case NPCID.Crimslime:
+                            target.AddBuff(BuffID.Slimed, Main.rand.Next(60, 600));
+                            target.AddBuff(mod.BuffType("Bloodthirsty"), Main.rand.Next(30, 240));
+                            break;
+
+                        case NPCID.Gastropod:
+                            target.AddBuff(BuffID.Slimed, Main.rand.Next(60, 600));
+                            target.AddBuff(mod.BuffType("Fused"), 1800);
+                            break;
+
+                        case NPCID.IlluminantSlime:
+                            target.AddBuff(BuffID.Slimed, Main.rand.Next(60, 600));
+                            target.AddBuff(mod.BuffType("Purified"), Main.rand.Next(30, 300));
+                            break;
+
+                        case NPCID.RainbowSlime:
+                            target.AddBuff(BuffID.Slimed, Main.rand.Next(30, 300));
+                            target.AddBuff(mod.BuffType("FlamesoftheUniverse"), Main.rand.Next(30, 120));
+                            break;
+
+                        case NPCID.DemonEye:
+                        case NPCID.DemonEyeOwl:
+                        case NPCID.DemonEyeSpaceship:
+                            if ((Math.Abs(npc.velocity.Y) > 5 || Math.Abs(npc.velocity.X) > 5) && !target.HasBuff(BuffID.Stoned))
+                                target.AddBuff(BuffID.Stoned, Main.rand.Next(30, 120));
+                            break;
+
+                        case NPCID.EaterofSouls:
+                        case NPCID.Crimera:
+                            target.AddBuff(BuffID.Weak, Main.rand.Next(300, 1800));
+                            break;
+
+                        case NPCID.EyeofCthulhu:
+                            target.AddBuff(mod.BuffType("Berserked"), Main.rand.Next(60, 600));
+                            break;
+
+                        case NPCID.ServantofCthulhu:
+                            target.AddBuff(mod.BuffType("Hexed"), Main.rand.Next(300));
+                            break;
+
+                        case NPCID.QueenBee:
+                            target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(300, 600));
+                            target.AddBuff(mod.BuffType("Crippled"), Main.rand.Next(300, 600));
+                            target.AddBuff(mod.BuffType("ClippedWings"), Main.rand.Next(300, 600));
+                            break;
+
+                        case NPCID.WallofFlesh:
+                        case NPCID.WallofFleshEye:
+                            if (!target.HasBuff(mod.BuffType("Unstable")))
+                                target.AddBuff(mod.BuffType("Unstable"), Main.rand.Next(60, 240));
+                            break;
+
+                        case NPCID.TheHungry:
+                        case NPCID.TheHungryII:
+                            target.AddBuff(mod.BuffType("Crippled"), Main.rand.Next(300, 600));
+                            target.velocity = target.velocity / 4;
+                            if (!BossIsAlive(ref wallBoss, NPCID.WallofFlesh))
+                            {
+                                NPC.SpawnWOF(target.Center);
+                                Main.PlaySound(15, (int)npc.position.X, (int)npc.position.Y, 0);
+                            }
+                            break;
+
+                        case NPCID.EaterofWorldsHead:
+                        case NPCID.EaterofWorldsBody:
+                        case NPCID.EaterofWorldsTail:
+                            target.AddBuff(mod.BuffType("Rotting"), Main.rand.Next(300, 1800));
+                            break;
+
+                        case NPCID.CursedSkull:
+                            if (Main.rand.Next(4) == 0)
+                                target.AddBuff(BuffID.Cursed, Main.rand.Next(60, 600));
+                            break;
+
+                        case NPCID.Snatcher:
+                            target.AddBuff(BuffID.Bleeding, Main.rand.Next(300, 1800));
+                            break;
+
+                        case NPCID.ManEater:
+                            target.AddBuff(BuffID.Bleeding, Main.rand.Next(300, 1800));
+                            if (target.statLife < 100)
+                                target.KillMe(PlayerDeathReason.ByCustomReason(target.name + " was eaten alive by a Man Eater."), 999, 0);
+                            break;
+
+                        case NPCID.TombCrawlerHead:
+                            if (target.statLife < 60)
+                                target.KillMe(PlayerDeathReason.ByCustomReason(target.name + " was eaten alive by a Tomb Crawler."), 999, 0);
+                            break;
+
+                        case NPCID.DevourerHead:
+                            target.AddBuff(BuffID.BrokenArmor, Main.rand.Next(90, 900));
+                            if (target.statLife < 50)
+                                target.KillMe(PlayerDeathReason.ByCustomReason(target.name + " was eaten alive by a Devourer."), 999, 0);
+                            break;
+
+                        case NPCID.AngryTrapper:
+                            target.AddBuff(BuffID.Bleeding, Main.rand.Next(300, 1800));
+                            if (target.statLife < 180)
+                                target.KillMe(PlayerDeathReason.ByCustomReason(target.name + " was eaten alive by an Angry Trapper."), 999, 0);
+                            break;
+
+                        case NPCID.SkeletronHead:
+                            target.AddBuff(mod.BuffType("Lethargic"), Main.rand.Next(150, 300));
+                            break;
+
+                        case NPCID.SkeletronHand:
+                            if (Main.rand.Next(2) == 0)
+                                target.AddBuff(mod.BuffType("Stunned"), Main.rand.Next(90));
+                            break;
+
+                        case NPCID.CaveBat:
+                            target.AddBuff(BuffID.Bleeding, Main.rand.Next(600, 1200));
+                            target.AddBuff(BuffID.Rabies, Main.rand.Next(7200));
+                            break;
+
+                        case NPCID.Hellbat:
+                            target.AddBuff(BuffID.OnFire, Main.rand.Next(300, 600));
+                            target.AddBuff(BuffID.Rabies, Main.rand.Next(7200));
+                            break;
+
+                        case NPCID.JungleBat:
+                            target.AddBuff(BuffID.Poisoned, Main.rand.Next(300, 600));
+                            target.AddBuff(BuffID.Rabies, Main.rand.Next(7200));
+                            break;
+
+                        case NPCID.IceBat:
+                            target.AddBuff(BuffID.Rabies, Main.rand.Next(7200));
+                            if (target.HasBuff(BuffID.Chilled) && !target.HasBuff(BuffID.Frozen))
+                                target.AddBuff(BuffID.Frozen, Main.rand.Next(120));
+                            break;
+
+                        case NPCID.Lavabat:
+                            int duration = Main.rand.Next(120, 600);
+                            target.AddBuff(BuffID.OnFire, duration);
+                            target.AddBuff(BuffID.Burning, duration);
+
+                            target.AddBuff(BuffID.Rabies, Main.rand.Next(7200));
+                            break;
+
+                        case NPCID.GiantBat:
+                            target.AddBuff(BuffID.Confused, Main.rand.Next(300));
+                            target.AddBuff(BuffID.Rabies, Main.rand.Next(7200));
+                            break;
+
+                        case NPCID.IlluminantBat:
+                            target.AddBuff(mod.BuffType("MutantNibble"), Main.rand.Next(1800, 3600));
+                            break;
+
+                        case NPCID.GiantFlyingFox:
+                            target.AddBuff(mod.BuffType("MutantNibble"), Main.rand.Next(600, 1200));
+                            target.AddBuff(mod.BuffType("Bloodthirsty"), Main.rand.Next(30, 300));
+                            target.AddBuff(BuffID.Rabies, Main.rand.Next(7200));
+                            break;
+
+                        case NPCID.VampireBat:
+                        case NPCID.Vampire:
+                            target.AddBuff(BuffID.Darkness, Main.rand.Next(900, 1800));
+                            target.AddBuff(BuffID.Weak, Main.rand.Next(900, 1800));
+                            target.AddBuff(BuffID.Rabies, Main.rand.Next(900, 1800));
+                            npc.life += damage / 2;
+                            CombatText.NewText(npc.Hitbox, CombatText.HealLife, damage / 2);
+                            npc.damage = (int)(npc.damage * 1.1f);
+                            break;
+
+                        case NPCID.SnowFlinx:
+                            target.AddBuff(mod.BuffType("Purified"), Main.rand.Next(180, 1800));
+                            break;
+
+                        case NPCID.Piranha:
+                            target.AddBuff(BuffID.Bleeding, Main.rand.Next(60, 600));
+                            break;
+
+                        case NPCID.Medusa:
+                            target.AddBuff(mod.BuffType("Flipped"), Main.rand.Next(90, 180));
+                            if (!target.HasBuff(BuffID.Stoned))
+                                target.AddBuff(BuffID.Stoned, Main.rand.Next(60, 120));
+                            break;
+
+                        case NPCID.SpikeBall:
+                            target.AddBuff(BuffID.BrokenArmor, Main.rand.Next(300, 1200));
+                            if (masoBool[0])
+                                target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(300, 1200));
+                            break;
+
+                        case NPCID.BlazingWheel:
+                            target.AddBuff(BuffID.OnFire, Main.rand.Next(60, 600));
+                            if (masoBool[0])
+                                target.AddBuff(mod.BuffType("FlamesoftheUniverse"), Main.rand.Next(300));
+                            break;
+
+                        case NPCID.Shark:
+                        case NPCID.SandShark:
+                        case NPCID.SandsharkCorrupt:
+                        case NPCID.SandsharkCrimson:
+                        case NPCID.SandsharkHallow:
+                            target.AddBuff(BuffID.Bleeding, Main.rand.Next(60, 300));
+                            break;
+
+                        case NPCID.GraniteFlyer:
+                        case NPCID.GraniteGolem:
+                            if (!target.HasBuff(BuffID.Stoned) && Main.rand.Next(2) == 0)
+                                target.AddBuff(BuffID.Stoned, Main.rand.Next(120));
+                            break;
+
+                        case NPCID.LeechHead:
+                            target.AddBuff(mod.BuffType("Crippled"), Main.rand.Next(300, 900));
+                            target.AddBuff(BuffID.Bleeding, Main.rand.Next(300, 900));
+                            target.AddBuff(BuffID.Rabies, Main.rand.Next(300, 900));
+                            break;
+
+                        case NPCID.AnomuraFungus:
+                            target.AddBuff(BuffID.Poisoned, Main.rand.Next(300, 600));
+                            break;
+
+                        case NPCID.WaterSphere:
+                            target.AddBuff(mod.BuffType("Flipped"), Main.rand.Next(600));
+                            target.AddBuff(BuffID.Wet, Main.rand.Next(1200));
+                            break;
+
+                        case NPCID.GiantShelly:
+                        case NPCID.GiantShelly2:
+                            target.AddBuff(BuffID.Slow, Main.rand.Next(30, 300));
+                            break;
+
+                        case NPCID.Squid:
+                            target.AddBuff(BuffID.Obstructed, Main.rand.Next(30, 300));
+                            break;
+
+                        case NPCID.BloodZombie:
+                            target.AddBuff(BuffID.Cursed, Main.rand.Next(240, 480));
+                            break;
+
+                        case NPCID.Drippler:
+                            target.AddBuff(mod.BuffType("Rotting"), Main.rand.Next(300, 600));
+                            break;
+
+                        case NPCID.ChaosBall:
+                            target.AddBuff(BuffID.ShadowFlame, Main.rand.Next(60, 600));
+                            break;
+
+                        case NPCID.Tumbleweed:
+                            target.AddBuff(mod.BuffType("Crippled"), Main.rand.Next(60, 300));
+                            break;
+
                         case NPCID.PigronCorruption:
                         case NPCID.PigronCrimson:
                         case NPCID.PigronHallow:
+                            target.AddBuff(mod.BuffType("SqueakyToy"), Main.rand.Next(300));
                             if (!BossIsAlive(ref fishBoss, NPCID.DukeFishron))
                             {
                                 npc.velocity = npc.Center - target.Center;
@@ -5415,11 +5737,620 @@ namespace FargowiltasSouls.NPCs
                             }
                             break;
 
-                        case NPCID.Vampire:
-                        case NPCID.VampireBat:
-                            npc.life += damage / 2;
-                            CombatText.NewText(npc.Hitbox, CombatText.HealLife, damage / 2);
-                            npc.damage = (int)(npc.damage * 1.1f);
+                        case NPCID.CorruptBunny:
+                        case NPCID.CrimsonBunny:
+                        case NPCID.CorruptGoldfish:
+                        case NPCID.CrimsonGoldfish:
+                        case NPCID.CorruptPenguin:
+                        case NPCID.CrimsonPenguin:
+                        case NPCID.MothronSpawn:
+                        case NPCID.Scutlix:
+                        case NPCID.Parrot:
+                        case NPCID.GingerbreadMan:
+                            target.AddBuff(mod.BuffType("SqueakyToy"), Main.rand.Next(300));
+                            break;
+
+                        case NPCID.FaceMonster:
+                            target.AddBuff(BuffID.Rabies, Main.rand.Next(1800));
+                            break;
+
+                        case NPCID.Harpy:
+                            target.AddBuff(mod.BuffType("ClippedWings"), Main.rand.Next(60, 600));
+                            break;
+
+                        case NPCID.SeaSnail:
+                            target.AddBuff(BuffID.OgreSpit, Main.rand.Next(300));
+                            break;
+
+                        case NPCID.BrainofCthulhu:
+                            target.AddBuff(mod.BuffType("Hexed"), Main.rand.Next(90));
+                            target.AddBuff(mod.BuffType("ClippedWings"), Main.rand.Next(300));
+                            target.AddBuff(mod.BuffType("Infested"), Main.rand.Next(300));
+                            target.AddBuff(mod.BuffType("Flipped"), Main.rand.Next(180));
+                            target.AddBuff(BuffID.Rabies, Main.rand.Next(900, 1800));
+                            break;
+
+                        case NPCID.Creeper:
+                            switch (Main.rand.Next(6))
+                            {
+                                case 0:
+                                    target.AddBuff(mod.BuffType("Berserked"), Main.rand.Next(240));
+                                    break;
+
+                                case 1:
+                                    target.AddBuff(mod.BuffType("Lethargic"), Main.rand.Next(240));
+                                    break;
+
+                                case 2:
+                                    target.AddBuff(mod.BuffType("Flipped"), Main.rand.Next(240));
+                                    break;
+
+                                case 3:
+                                    target.AddBuff(mod.BuffType("Infested"), Main.rand.Next(240));
+                                    break;
+
+                                case 4:
+                                    target.AddBuff(mod.BuffType("Rotting"), Main.rand.Next(240));
+                                    break;
+
+                                case 5:
+                                    target.AddBuff(BuffID.Rabies, Main.rand.Next(900));
+                                    break;
+                            }
+                            break;
+
+                        case NPCID.SwampThing:
+                            target.AddBuff(BuffID.OgreSpit, Main.rand.Next(30, 300));
+                            break;
+
+                        case NPCID.Frankenstein:
+                            target.AddBuff(mod.BuffType("LightningRod"), Main.rand.Next(60, 600));
+                            break;
+
+                        case NPCID.Butcher:
+                            target.AddBuff(mod.BuffType("Berserked"), Main.rand.Next(300, 600));
+                            target.AddBuff(BuffID.Bleeding, Main.rand.Next(900, 1800));
+                            break;
+
+                        case NPCID.ThePossessed:
+                            target.AddBuff(mod.BuffType("Hexed"), Main.rand.Next(240));
+                            break;
+
+                        case NPCID.Wolf:
+                            target.AddBuff(mod.BuffType("Crippled"), 300);
+                            target.AddBuff(BuffID.Rabies, Main.rand.Next(1800));
+                            break;
+
+                        case NPCID.Werewolf:
+                            target.AddBuff(BuffID.Rabies, Main.rand.Next(1800));
+                            break;
+
+                        //all armored bones
+                        case 269:
+                        case 270:
+                        case 271:
+                        case 272:
+                        case 273:
+                        case 274:
+                        case 275:
+                        case 276:
+                        case 277:
+                        case 278:
+                        case 279:
+                        case 280: target.AddBuff(mod.BuffType("Bloodthirsty"), Main.rand.Next(90)); break;
+
+                        case NPCID.GiantTortoise:
+                            target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(60, 300));
+                            break;
+
+                        case NPCID.IceTortoise:
+                            target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(60, 300));
+                            if (Main.rand.Next(3) == 0)
+                                target.AddBuff(BuffID.Frozen, Main.rand.Next(120));
+                            break;
+
+                        //CULTIST OP
+                        case NPCID.AncientDoom:
+                            target.AddBuff(mod.BuffType("MarkedforDeath"), 120);
+                            break;
+                        case NPCID.AncientLight:
+                            target.AddBuff(mod.BuffType("Purified"), Main.rand.Next(60, 180));
+                            break;
+                        case NPCID.CultistBossClone:
+                            target.AddBuff(mod.BuffType("Hexed"), Main.rand.Next(60, 120));
+                            target.AddBuff(mod.BuffType("CurseoftheMoon"), Main.rand.Next(600, 900));
+                            break;
+
+                        case NPCID.MossHornet:
+                            target.AddBuff(mod.BuffType("Infested"), Main.rand.Next(30, 300));
+                            break;
+
+                        case NPCID.Paladin:
+                            target.AddBuff(mod.BuffType("Lethargic"), Main.rand.Next(480, 720));
+                            break;
+
+                        case NPCID.DukeFishron:
+                            target.AddBuff(mod.BuffType("MutantNibble"), Main.rand.Next(600, 900));
+                            target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(600, 900));
+                            target.AddBuff(BuffID.BrokenArmor, Main.rand.Next(600, 900));
+                            target.AddBuff(BuffID.WitheredArmor, Main.rand.Next(600, 900));
+                            target.AddBuff(BuffID.Rabies, Main.rand.Next(3600, 7200));
+                            target.GetModPlayer<FargoPlayer>(mod).MaxLifeReduction += (npc.whoAmI == fishBossEX) ? 150 : 100;
+                            target.AddBuff(mod.BuffType("OceanicMaul"), Main.rand.Next(3600, 7200));
+                            break;
+
+                        case NPCID.Sharkron:
+                        case NPCID.Sharkron2:
+                            target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(600, 900));
+                            target.AddBuff(mod.BuffType("MutantNibble"), Main.rand.Next(300, 600));
+                            target.AddBuff(BuffID.Rabies, Main.rand.Next(3600, 7200));
+                            if (BossIsAlive(ref fishBossEX, NPCID.DukeFishron))
+                            {
+                                target.GetModPlayer<FargoPlayer>(mod).MaxLifeReduction += 100;
+                                target.AddBuff(mod.BuffType("OceanicMaul"), Main.rand.Next(1800, 3600));
+                            }
+                            break;
+
+                        case NPCID.DetonatingBubble:
+                            target.AddBuff(mod.BuffType("SqueakyToy"), Main.rand.Next(60, 180));
+                            if (BossIsAlive(ref fishBossEX, NPCID.DukeFishron))
+                            {
+                                target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(600, 900));
+                                target.GetModPlayer<FargoPlayer>(mod).MaxLifeReduction += 50;
+                                target.AddBuff(mod.BuffType("OceanicMaul"), Main.rand.Next(1800, 3600));
+                            }
+                            break;
+
+                        case NPCID.Hellhound:
+                            target.AddBuff(BuffID.WitheredWeapon, Main.rand.Next(900));
+                            target.AddBuff(BuffID.Obstructed, Main.rand.Next(180));
+                            break;
+
+                        case NPCID.Mimic:
+                        case NPCID.PresentMimic:
+                            target.AddBuff(mod.BuffType("Purified"), Main.rand.Next(120));
+                            break;
+
+                        case NPCID.BigMimicCorruption:
+                        case NPCID.BigMimicCrimson:
+                        case NPCID.BigMimicHallow:
+                        case NPCID.BigMimicJungle:
+                            target.AddBuff(mod.BuffType("Berserked"), 300);
+                            goto case NPCID.Mimic;
+
+                        case NPCID.RuneWizard:
+                            target.AddBuff(mod.BuffType("MarkedforDeath"), 120);
+                            target.AddBuff(mod.BuffType("Unstable"), 30);
+                            break;
+
+                        case NPCID.Nutcracker:
+                        case NPCID.NutcrackerSpinning:
+                            if (target.Male)
+                            {
+                                target.statDefense = 0;
+                                target.endurance = 0;
+                                target.KillMe(PlayerDeathReason.ByCustomReason(target.name + " got his nuts cracked."), 9999, 0);
+                            }
+                            else
+                            {
+                                target.AddBuff(BuffID.Bleeding, Main.rand.Next(900, 1800));
+                            }
+                            break;
+
+                        case NPCID.Wraith:
+                            target.AddBuff(mod.BuffType("LivingWasteland"), Main.rand.Next(300, 900));
+                            break;
+
+                        case NPCID.Plantera:
+                            target.AddBuff(mod.BuffType("MutantNibble"), Main.rand.Next(600, 900));
+                            goto case NPCID.PlanterasHook;
+
+                        case NPCID.PlanterasHook:
+                        case NPCID.PlanterasTentacle:
+                        case NPCID.Spore:
+                            target.AddBuff(BuffID.Poisoned, Main.rand.Next(120, 600));
+                            target.AddBuff(mod.BuffType("Infested"), Main.rand.Next(60, 300));
+                            bool isVenomed = false;
+                            for (int i = 0; i < 22; i++)
+                            {
+                                if (target.buffType[i] == BuffID.Venom && target.buffTime[i] > 1)
+                                {
+                                    isVenomed = true;
+                                    target.buffTime[i] += Main.rand.Next(60, 180);
+                                    if (target.buffTime[i] > 1200)
+                                    {
+                                        target.AddBuff(mod.BuffType("Infested"), target.buffTime[i]);
+                                        Main.PlaySound(15, (int)target.Center.X, (int)target.Center.Y, 0);
+                                    }
+                                    break;
+                                }
+                            }
+                            if (!isVenomed)
+                            {
+                                target.AddBuff(BuffID.Venom, Main.rand.Next(60, 300));
+                            }
+                            break;
+
+                        case NPCID.ChaosElemental:
+                            target.AddBuff(mod.BuffType("Unstable"), Main.rand.Next(600));
+                            break;
+
+                        case NPCID.Flocko:
+                            target.AddBuff(BuffID.Chilled, Main.rand.Next(900, 1800));
+                            target.AddBuff(BuffID.Frostburn, Main.rand.Next(60, 600));
+                            break;
+
+                        case NPCID.GoblinThief:
+                            if (target.whoAmI == Main.myPlayer && Main.rand.Next(2) == 0)
+                            {
+                                //try stealing mouse item, then selected item
+                                if (!StealFromInventory(target, ref Main.mouseItem))
+                                    StealFromInventory(target, ref target.inventory[target.selectedItem]);
+
+                                byte extraTries = 30;
+                                for (int i = 0; i < 3; i++)
+                                {
+                                    bool successfulSteal = StealFromInventory(target, ref target.inventory[Main.rand.Next(target.inventory.Length)]);
+
+                                    if (!successfulSteal && extraTries > 0)
+                                    {
+                                        extraTries--;
+                                        i--;
+                                    }
+                                }
+                            }
+                            goto case NPCID.PirateCorsair;
+
+                        case NPCID.PirateCaptain:
+                        case NPCID.PirateCorsair:
+                        case NPCID.PirateCrossbower:
+                        case NPCID.PirateDeadeye:
+                        case NPCID.PirateShipCannon:
+                            target.DropCoins();
+                            break;
+
+                        case NPCID.PirateDeckhand:
+                            npc.Transform(NPCID.PirateCaptain);
+                            npc.GetGlobalNPC<FargoGlobalNPC>().dropLoot = false;
+                            target.DropCoins();
+                            goto case NPCID.GrayGrunt;
+
+                        case NPCID.GoblinPeon:
+                        case NPCID.GrayGrunt:
+                            if (Main.hardMode)
+                                target.AddBuff(mod.BuffType("LivingWasteland"), Main.rand.Next(300, 900));
+                            break;
+
+                        case NPCID.Zombie:
+                        case NPCID.ArmedZombie:
+                        case NPCID.ArmedZombieCenx:
+                        case NPCID.ArmedZombiePincussion:
+                        case NPCID.ArmedZombieSlimed:
+                        case NPCID.ArmedZombieSwamp:
+                        case NPCID.ArmedZombieTwiggy:
+                        case NPCID.BaldZombie:
+                        case NPCID.FemaleZombie:
+                        case NPCID.PincushionZombie:
+                        case NPCID.SlimedZombie:
+                        case NPCID.TwiggyZombie:
+                        case NPCID.ZombiePixie:
+                        case NPCID.ZombieRaincoat:
+                        case NPCID.ZombieSuperman:
+                        case NPCID.ZombieSweater:
+                        case NPCID.ZombieXmas:
+                        case NPCID.ZombieMushroom:
+                        case NPCID.ZombieMushroomHat:
+                        case NPCID.SwampZombie:
+                        case NPCID.SmallSwampZombie:
+                        case NPCID.BigSwampZombie:
+                        case NPCID.ZombieDoctor:
+                            target.AddBuff(mod.BuffType("Rotting"), Main.rand.Next(60, 600));
+                            break;
+
+                        case NPCID.ZombieEskimo:
+                        case NPCID.ArmedZombieEskimo:
+                            target.AddBuff(BuffID.Chilled, Main.rand.Next(300));
+                            break;
+
+                        case NPCID.Corruptor:
+                            target.AddBuff(BuffID.Weak, Main.rand.Next(60, 7200));
+                            target.AddBuff(mod.BuffType("Rotting"), Main.rand.Next(300, 3600));
+                            break;
+
+                        case NPCID.Mummy:
+                        case NPCID.LightMummy:
+                        case NPCID.DarkMummy:
+                            if (!target.HasBuff(BuffID.Webbed))
+                                target.AddBuff(BuffID.Webbed, Main.rand.Next(30, 300));
+                            break;
+
+                        case NPCID.Derpling:
+                            target.AddBuff(mod.BuffType("Lethargic"), Main.rand.Next(600, 1200));
+                            break;
+
+                        case NPCID.Spazmatism:
+                            if (masoBool[1] && Main.rand.Next(3) == 0)
+                                target.AddBuff(BuffID.CursedInferno, 480);
+                            break;
+                        /*case NPCID.Retinazer:
+                            target.AddBuff(mod.BuffType("Crippled"), Main.rand.Next(120, 240));
+                            target.AddBuff(mod.BuffType("ClippedWings"), Main.rand.Next(120, 240));
+                            break;*/
+
+                        case NPCID.TheDestroyer:
+                            target.AddBuff(mod.BuffType("Crippled"), Main.rand.Next(300, 1200));
+                            target.AddBuff(mod.BuffType("ClippedWings"), Main.rand.Next(300, 1200));
+                            if (target.statLife < 300)
+                                target.KillMe(PlayerDeathReason.ByCustomReason(target.name + " was eaten alive by the Destroyer."), 9999, 0);
+                            goto case NPCID.TheDestroyerTail;
+
+                        case NPCID.TheDestroyerBody:
+                        case NPCID.TheDestroyerTail:
+                            target.AddBuff(mod.BuffType("LightningRod"), Main.rand.Next(300, 1200));
+                            break;
+
+                        case NPCID.SkeletronPrime:
+                            target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(180, 300));
+                            break;
+
+                        case NPCID.PrimeVice:
+                            if (target.mount.Active)
+                                target.mount.Dismount(target);
+                            target.AddBuff(mod.BuffType("Stunned"), Main.rand.Next(30, 90));
+                            break;
+
+                        /*case NPCID.PrimeCannon:
+                        case NPCID.PrimeLaser:
+                        case NPCID.PrimeSaw:
+                        case NPCID.Probe:
+                            target.AddBuff(mod.BuffType("ClippedWings"), 15); //all mech cases come here
+                            break;*/
+
+                        case NPCID.BlackRecluse:
+                            target.AddBuff(BuffID.Poisoned, Main.rand.Next(30, 300));
+                            target.AddBuff(mod.BuffType("Rotting"), Main.rand.Next(60, 1800));
+                            break;
+
+                        case NPCID.DesertBeast:
+                            target.AddBuff(mod.BuffType("Crippled"), Main.rand.Next(300, 900));
+                            break;
+
+                        case NPCID.FlyingSnake:
+                            target.AddBuff(mod.BuffType("Infested"), Main.rand.Next(300, 600));
+                            target.AddBuff(mod.BuffType("ClippedWings"), Main.rand.Next(600, 1200));
+                            break;
+
+                        case NPCID.Lihzahrd:
+                        case NPCID.LihzahrdCrawler:
+                            target.AddBuff(mod.BuffType("Infested"), Main.rand.Next(60, 300));
+                            target.AddBuff(mod.BuffType("Bloodthirsty"), Main.rand.Next(120));
+                            break;
+
+                        case NPCID.CultistDragonHead:
+                            target.AddBuff(mod.BuffType("CurseoftheMoon"), Main.rand.Next(300, 600));
+                            target.AddBuff(mod.BuffType("ClippedWings"), Main.rand.Next(60, 300));
+                            target.AddBuff(mod.BuffType("MutantNibble"), Main.rand.Next(300, 600));
+                            break;
+                        //goto case NPCID.CultistDragonTail;
+
+                        /*case NPCID.CultistDragonBody1:
+                        case NPCID.CultistDragonBody2:
+                        case NPCID.CultistDragonBody3:
+                        case NPCID.CultistDragonBody4:
+                        case NPCID.CultistDragonTail:
+                            target.AddBuff(mod.BuffType("ClippedWings"), 15);
+                            break;*/
+
+                        case NPCID.AncientCultistSquidhead:
+                            target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(120, 480));
+                            if (Main.rand.Next(2) == 0)
+                                target.AddBuff(mod.BuffType("Flipped"), Main.rand.Next(30, 60));
+                            else
+                                target.AddBuff(mod.BuffType("Unstable"), Main.rand.Next(30, 60));
+                            break;
+
+                        case NPCID.SolarCrawltipedeHead:
+                            target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(600, 1200));
+                            if (target.statLife < 200)
+                                target.KillMe(PlayerDeathReason.ByCustomReason(target.name + " was eaten alive by a Crawltipede."), 999, 0);
+                            break;
+
+                        case NPCID.BoneLee:
+                            target.AddBuff(BuffID.Obstructed, Main.rand.Next(60));
+                            break;
+
+                        case NPCID.Pumpking:
+                        case NPCID.PumpkingBlade:
+                            target.AddBuff(BuffID.Weak, Main.rand.Next(900, 1800));
+                            target.AddBuff(mod.BuffType("Rotting"), Main.rand.Next(900, 1800));
+                            break;
+
+                        case NPCID.MourningWood:
+                            int duration1 = Main.rand.Next(120, 240);
+                            target.AddBuff(BuffID.OnFire, duration1);
+                            target.AddBuff(BuffID.CursedInferno, duration1);
+                            target.AddBuff(BuffID.ShadowFlame, duration1);
+                            break;
+
+                        case NPCID.VortexHornet:
+                        case NPCID.VortexHornetQueen:
+                        case NPCID.VortexSoldier:
+                        case NPCID.VortexRifleman:
+                            target.AddBuff(mod.BuffType("LightningRod"), Main.rand.Next(60, 600));
+                            target.AddBuff(mod.BuffType("ClippedWings"), Main.rand.Next(30, 300));
+                            break;
+
+                        case NPCID.ZombieElf:
+                        case NPCID.ZombieElfBeard:
+                        case NPCID.ZombieElfGirl:
+                            target.AddBuff(mod.BuffType("Rotting"), Main.rand.Next(300, 1800));
+                            break;
+
+                        case NPCID.Krampus:
+                            if (target.whoAmI == Main.myPlayer)
+                            {
+                                //try stealing mouse item, then selected item
+                                if (!StealFromInventory(target, ref Main.mouseItem))
+                                    StealFromInventory(target, ref target.inventory[target.selectedItem]);
+
+                                StealFromInventory(target, ref target.armor[Main.rand.Next(3)]);
+
+                                byte maxAttempts = 15;
+                                for (int i = 0; i < 3; i++)
+                                {
+                                    int toss = Main.rand.Next(3, 8 + target.extraAccessorySlots); //pick random accessory slot
+                                    if (Main.rand.Next(3) == 0 && target.armor[toss + 10].stack > 0) //chance to pick vanity slot if accessory is there
+                                    {
+                                        toss += 10;
+                                    }
+
+                                    bool successfulSteal = StealFromInventory(target, ref target.armor[toss]);
+
+                                    if (!successfulSteal && maxAttempts > 0)
+                                    {
+                                        maxAttempts--;
+                                        i--;
+                                    }
+                                }
+                            }
+                            break;
+
+                        case NPCID.GigaZapper:
+                            target.AddBuff(mod.BuffType("LightningRod"), Main.rand.Next(300, 600));
+                            break;
+
+                        case NPCID.Clown:
+                            target.AddBuff(mod.BuffType("Fused"), 180);
+                            target.AddBuff(mod.BuffType("Hexed"), 1200);
+                            break;
+
+                        case NPCID.UndeadMiner:
+                            int length = Main.rand.Next(3600, 7200);
+                            target.AddBuff(mod.BuffType("Lethargic"), length * 2);
+                            target.AddBuff(BuffID.Blackout, length);
+                            target.AddBuff(BuffID.NoBuilding, length);
+                            for (int i = 0; i < 59; i++)
+                            {
+                                if (target.inventory[i].pick != 0 || target.inventory[i].hammer != 0 || target.inventory[i].axe != 0)
+                                    StealFromInventory(target, ref target.inventory[i]);
+                            }
+                            break;
+
+                        case NPCID.Golem:
+                        case NPCID.GolemFistLeft:
+                        case NPCID.GolemFistRight:
+                            target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(300, 600));
+                            target.AddBuff(BuffID.BrokenArmor, Main.rand.Next(60, 300));
+                            break;
+
+                        case NPCID.DD2Betsy:
+                            target.AddBuff(mod.BuffType("MutantNibble"), Main.rand.Next(300, 600));
+                            target.AddBuff(BuffID.Rabies, Main.rand.Next(3600, 7200));
+                            target.AddBuff(BuffID.WitheredArmor, Main.rand.Next(300, 600));
+                            target.AddBuff(BuffID.WitheredWeapon, Main.rand.Next(300, 600));
+                            target.AddBuff(BuffID.Ichor, Main.rand.Next(600, 900));
+                            target.AddBuff(BuffID.OnFire, Main.rand.Next(900, 1800));
+                            break;
+
+                        case NPCID.DD2WyvernT1:
+                        case NPCID.DD2WyvernT2:
+                        case NPCID.DD2WyvernT3:
+                            target.AddBuff(mod.BuffType("MutantNibble"), Main.rand.Next(300, 600));
+                            target.AddBuff(BuffID.Rabies, Main.rand.Next(3600, 7200));
+                            break;
+
+                        case NPCID.DD2KoboldFlyerT2:
+                        case NPCID.DD2KoboldFlyerT3:
+                        case NPCID.DD2KoboldWalkerT2:
+                        case NPCID.DD2KoboldWalkerT3:
+                            target.AddBuff(mod.BuffType("Fused"), 1800);
+                            break;
+
+                        case NPCID.DD2OgreT2:
+                        case NPCID.DD2OgreT3:
+                            target.AddBuff(mod.BuffType("Stunned"), Main.rand.Next(30, 60));
+                            target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(180, 300));
+                            target.AddBuff(BuffID.BrokenArmor, Main.rand.Next(300, 600));
+                            break;
+
+                        case NPCID.DD2LightningBugT3:
+                            target.AddBuff(BuffID.Electrified, Main.rand.Next(300, 600));
+                            break;
+
+                        case NPCID.DD2SkeletonT1:
+                        case NPCID.DD2SkeletonT3:
+                            target.AddBuff(BuffID.ShadowFlame, Main.rand.Next(300, 600));
+                            target.AddBuff(mod.BuffType("Rotting"), Main.rand.Next(1200, 2400));
+                            break;
+
+                        case NPCID.SolarSpearman:
+                        case NPCID.SolarSroller:
+                            target.AddBuff(BuffID.OnFire, Main.rand.Next(300, 600));
+                            target.AddBuff(BuffID.Burning, Main.rand.Next(60, 300));
+                            break;
+
+                        case NPCID.SolarSolenian:
+                            target.AddBuff(BuffID.OnFire, Main.rand.Next(300, 600));
+                            target.AddBuff(BuffID.Ichor, Main.rand.Next(600, 1200));
+                            break;
+
+                        case NPCID.SolarDrakomire:
+                        case NPCID.SolarDrakomireRider:
+                            target.AddBuff(BuffID.OnFire, Main.rand.Next(300, 600));
+                            target.AddBuff(BuffID.Rabies, Main.rand.Next(7200));
+                            break;
+
+                        case NPCID.DesertScorpionWalk:
+                        case NPCID.DesertScorpionWall:
+                        case NPCID.MisterStabby:
+                            target.AddBuff(mod.BuffType("MarkedforDeath"), Main.rand.Next(60, 180));
+                            break;
+
+                        case NPCID.NebulaHeadcrab:
+                            target.AddBuff(mod.BuffType("Unstable"), Main.rand.Next(60, 180));
+                            target.AddBuff(mod.BuffType("Flipped"), Main.rand.Next(60, 180));
+                            break;
+
+                        case NPCID.StardustCellBig:
+                        case NPCID.StardustCellSmall:
+                            target.AddBuff(mod.BuffType("SqueakyToy"), Main.rand.Next(60, 180));
+                            break;
+
+                        case NPCID.StardustWormHead:
+                        case NPCID.StardustWormBody:
+                        case NPCID.StardustWormTail:
+                            target.AddBuff(mod.BuffType("Berserked"), Main.rand.Next(60, 300));
+                            break;
+
+                        case NPCID.StardustSpiderBig:
+                        case NPCID.StardustSpiderSmall:
+                            target.AddBuff(BuffID.Frostburn, Main.rand.Next(300, 600));
+                            break;
+
+                        case NPCID.MoonLordFreeEye:
+                        case NPCID.MoonLordHand:
+                        case NPCID.MoonLordHead:
+                            target.AddBuff(mod.BuffType("CurseoftheMoon"), 600);
+                            break;
+
+                        case NPCID.BoneSerpentHead:
+                            target.AddBuff(BuffID.Burning, Main.rand.Next(300, 600));
+                            break;
+
+                        case NPCID.Salamander:
+                        case NPCID.Salamander2:
+                        case NPCID.Salamander3:
+                        case NPCID.Salamander4:
+                        case NPCID.Salamander5:
+                        case NPCID.Salamander6:
+                        case NPCID.Salamander7:
+                        case NPCID.Salamander8:
+                        case NPCID.Salamander9:
+                            target.AddBuff(BuffID.Poisoned, Main.rand.Next(600, 900));
+                            break;
+
+                        case NPCID.VileSpit:
+                            target.AddBuff(mod.BuffType("Rotting"), Main.rand.Next(240, 360));
                             break;
 
                         default:
@@ -6894,9 +7825,19 @@ namespace FargowiltasSouls.NPCs
 
                             return false;
                         }
-                        else if (FargoWorld.FishronCount < 120)
+                        else
                         {
-                            FargoWorld.FishronCount++;
+                            if (FargoWorld.FishronCount < 120)
+                            {
+                                FargoWorld.FishronCount++;
+                            }
+
+                            if (fishBossEX == npc.whoAmI)
+                            {
+                                if (!FargoWorld.downedFishronEX)
+                                    Main.NewText("The ocean stirs...", 0, 100, 255);
+                                FargoWorld.downedFishronEX = true;
+                            }
                         }
                         break;
 
@@ -7598,937 +8539,16 @@ namespace FargowiltasSouls.NPCs
         {
             FargoPlayer modPlayer = target.GetModPlayer<FargoPlayer>(mod);
 
-            if (FargoWorld.MasochistMode)
+            /*if (FargoWorld.MasochistMode)
             {
                 switch (npc.type)
                 {
-                    case NPCID.BlueSlime:
-                        switch (npc.netID)
-                        {
-                            case NPCID.BlackSlime:
-                                target.AddBuff(BuffID.Slimed, Main.rand.Next(30, 300));
-                                target.AddBuff(BuffID.Darkness, Main.rand.Next(120, 1200));
-                                break;
-
-                            case NPCID.BabySlime:
-                                target.AddBuff(BuffID.Slimed, Main.rand.Next(240));
-                                break;
-
-                            case NPCID.Pinky:
-                                target.AddBuff(BuffID.Slimed, Main.rand.Next(300, 600));
-				                target.AddBuff(mod.BuffType("Stunned"), Main.rand.Next(120));
-                                break;
-
-                            default:
-                                target.AddBuff(BuffID.Slimed, Main.rand.Next(30, 300));
-                                break;
-                        }
-                        break;
-
-                    case NPCID.SpikedIceSlime:
-                        target.AddBuff(BuffID.Slimed, Main.rand.Next(30, 300));
-                        target.AddBuff(BuffID.Frostburn, Main.rand.Next(60, 300));
-                        break;
-
-                    case NPCID.SpikedJungleSlime:
-                        target.AddBuff(BuffID.Slimed, Main.rand.Next(30, 300));
-                        target.AddBuff(BuffID.Venom, Main.rand.Next(60, 300));
-                        break;
-
-                    case NPCID.MotherSlime:
-                        target.AddBuff(BuffID.Slimed, Main.rand.Next(30, 300));
-                        target.AddBuff(mod.BuffType("Antisocial"), Main.rand.Next(180, 1800));
-                        break;
-
-                    case NPCID.LavaSlime:
-                        target.AddBuff(BuffID.Oiled, Main.rand.Next(900, 1800));
-                        target.AddBuff(BuffID.OnFire, Main.rand.Next(120, 600));
-                        break;
-
-                    case NPCID.DungeonSlime:
-                        target.AddBuff(BuffID.Slimed, Main.rand.Next(30, 300));
-                        target.AddBuff(BuffID.Blackout, Main.rand.Next(120, 1200));
-                        break;
-
-                    case NPCID.KingSlime:
-                        target.AddBuff(BuffID.Slimed, Main.rand.Next(60, 600));
-                        target.AddBuff(mod.BuffType("ClippedWings"), Main.rand.Next(300, 600));
-
-                        if (Main.rand.Next(5) == 0 && !target.HasBuff(mod.BuffType("Stunned")))
-                            target.AddBuff(mod.BuffType("Stunned"), Main.rand.Next(30, 120));
-                        break;
-
-                    case NPCID.ToxicSludge:
-                        target.AddBuff(BuffID.Slimed, Main.rand.Next(60, 600));
-                        target.AddBuff(mod.BuffType("Infested"), Main.rand.Next(300, 600));
-                        break;
-
-                    case NPCID.CorruptSlime:
-                        target.AddBuff(BuffID.Slimed, Main.rand.Next(60, 600));
-                        target.AddBuff(mod.BuffType("Rotting"), Main.rand.Next(300, 1200));
-                        break;
-
-                    case NPCID.Crimslime:
-                        target.AddBuff(BuffID.Slimed, Main.rand.Next(60, 600));
-                        target.AddBuff(mod.BuffType("Bloodthirsty"), Main.rand.Next(30, 240));
-                        break;
-
-                    case NPCID.Gastropod:
-                        target.AddBuff(BuffID.Slimed, Main.rand.Next(60, 600));
-                        target.AddBuff(mod.BuffType("Fused"), 1800);
-                        break;
-
-                    case NPCID.IlluminantSlime:
-                        target.AddBuff(BuffID.Slimed, Main.rand.Next(60, 600));
-                        target.AddBuff(mod.BuffType("Purified"), Main.rand.Next(30, 300));
-                        break;
-
-                    case NPCID.RainbowSlime:
-                        target.AddBuff(BuffID.Slimed, Main.rand.Next(30, 300));
-                        target.AddBuff(mod.BuffType("FlamesoftheUniverse"), Main.rand.Next(30, 120));
-                        break;
-
-                    case NPCID.DemonEye:
-                    case NPCID.DemonEyeOwl:
-                    case NPCID.DemonEyeSpaceship:
-                        if ((Math.Abs(npc.velocity.Y) > 5 || Math.Abs(npc.velocity.X) > 5) && !target.HasBuff(BuffID.Stoned))
-                            target.AddBuff(BuffID.Stoned, Main.rand.Next(30, 120));
-                        break;
-
-                    case NPCID.EaterofSouls:
-                    case NPCID.Crimera:
-                        target.AddBuff(BuffID.Weak, Main.rand.Next(300, 1800));
-                        break;
-
-                    case NPCID.EyeofCthulhu:
-                        target.AddBuff(mod.BuffType("Berserked"), Main.rand.Next(60, 600));
-                        break;
-
-                    case NPCID.ServantofCthulhu:
-                        target.AddBuff(mod.BuffType("Hexed"), Main.rand.Next(300));
-                        break;
-
-                    case NPCID.QueenBee:
-                        target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(300, 600));
-                        target.AddBuff(mod.BuffType("Crippled"), Main.rand.Next(300, 600));
-                        target.AddBuff(mod.BuffType("ClippedWings"), Main.rand.Next(300, 600));
-                        break;
-
-                    case NPCID.WallofFlesh:
-                    case NPCID.WallofFleshEye:
-                        if (!target.HasBuff(mod.BuffType("Unstable")))
-                            target.AddBuff(mod.BuffType("Unstable"), Main.rand.Next(60, 240));
-                        break;
-
-                    case NPCID.TheHungry:
-                    case NPCID.TheHungryII:
-                        target.AddBuff(mod.BuffType("Crippled"), Main.rand.Next(300, 600));
-                        target.velocity = target.velocity / 4;
-                        break;
-
-                    case NPCID.EaterofWorldsHead:
-                    case NPCID.EaterofWorldsBody:
-                    case NPCID.EaterofWorldsTail:
-                        target.AddBuff(mod.BuffType("Rotting"), Main.rand.Next(300, 1800));
-                        break;
-
-                    case NPCID.CursedSkull:
-                        if (Main.rand.Next(4) == 0)
-                            target.AddBuff(BuffID.Cursed, Main.rand.Next(60, 600));
-                        break;
-
-                    case NPCID.Snatcher:
-                        target.AddBuff(BuffID.Bleeding, Main.rand.Next(300, 1800));
-                        break;
-
-                    case NPCID.ManEater:
-                        target.AddBuff(BuffID.Bleeding, Main.rand.Next(300, 1800));
-                        if (target.statLife < 100)
-                            target.KillMe(PlayerDeathReason.ByCustomReason(target.name + " was eaten alive by a Man Eater."), 999, 0);
-                        break;
-
-                    case NPCID.TombCrawlerHead:
-                        if (target.statLife < 60)
-                            target.KillMe(PlayerDeathReason.ByCustomReason(target.name + " was eaten alive by a Tomb Crawler."), 999, 0);
-                        break;
-
-                    case NPCID.DevourerHead:
-                        target.AddBuff(BuffID.BrokenArmor, Main.rand.Next(90, 900));
-                        if (target.statLife < 50)
-                            target.KillMe(PlayerDeathReason.ByCustomReason(target.name + " was eaten alive by a Devourer."), 999, 0);
-                        break;
-
-                    case NPCID.AngryTrapper:
-                        target.AddBuff(BuffID.Bleeding, Main.rand.Next(300, 1800));
-                        if (target.statLife < 180)
-                            target.KillMe(PlayerDeathReason.ByCustomReason(target.name + " was eaten alive by an Angry Trapper."), 999, 0);
-                        break;
-
-                    case NPCID.SkeletronHead:
-                        target.AddBuff(mod.BuffType("Lethargic"), Main.rand.Next(150, 300));
-                        break;
-
-                    case NPCID.SkeletronHand:
-                        if (Main.rand.Next(2) == 0)
-                            target.AddBuff(mod.BuffType("Stunned"), Main.rand.Next(90));
-                        break;
-
-                    case NPCID.CaveBat:
-                        target.AddBuff(BuffID.Bleeding, Main.rand.Next(600, 1200));
-                        target.AddBuff(BuffID.Rabies, Main.rand.Next(7200));
-                        break;
-
-                    case NPCID.Hellbat:
-                        target.AddBuff(BuffID.OnFire, Main.rand.Next(300, 600));
-                        target.AddBuff(BuffID.Rabies, Main.rand.Next(7200));
-                        break;
-
-                    case NPCID.JungleBat:
-                        target.AddBuff(BuffID.Poisoned, Main.rand.Next(300, 600));
-                        target.AddBuff(BuffID.Rabies, Main.rand.Next(7200));
-                        break;
-
-                    case NPCID.IceBat:
-                        target.AddBuff(BuffID.Rabies, Main.rand.Next(7200));
-                        if (target.HasBuff(BuffID.Chilled) && !target.HasBuff(BuffID.Frozen))
-                            target.AddBuff(BuffID.Frozen, Main.rand.Next(120));
-                        break;
-
-                    case NPCID.Lavabat:
-                        int duration = Main.rand.Next(120, 600);
-                        target.AddBuff(BuffID.OnFire, duration);
-                        target.AddBuff(BuffID.Burning, duration);
-
-                        target.AddBuff(BuffID.Rabies, Main.rand.Next(7200));
-                        break;
-
-                    case NPCID.GiantBat:
-                        target.AddBuff(BuffID.Confused, Main.rand.Next(300));
-                        target.AddBuff(BuffID.Rabies, Main.rand.Next(7200));
-                        break;
-
-                    case NPCID.IlluminantBat:
-                        target.AddBuff(mod.BuffType("MutantNibble"), Main.rand.Next(1800, 3600));
-                        break;
-
-                    case NPCID.GiantFlyingFox:
-                        target.AddBuff(mod.BuffType("MutantNibble"), Main.rand.Next(600, 1200));
-                        target.AddBuff(mod.BuffType("Bloodthirsty"), Main.rand.Next(30, 300));
-                        target.AddBuff(BuffID.Rabies, Main.rand.Next(7200));
-                        break;
-
-                    case NPCID.VampireBat:
-                    case NPCID.Vampire:
-                        target.AddBuff(BuffID.Darkness, Main.rand.Next(900, 1800));
-                        target.AddBuff(BuffID.Weak, Main.rand.Next(900, 1800));
-                        target.AddBuff(BuffID.Rabies, Main.rand.Next(900, 1800));
-                        break;
-
-                    case NPCID.SnowFlinx:
-                        target.AddBuff(mod.BuffType("Purified"), Main.rand.Next(180, 1800));
-                        break;
-
-                    case NPCID.Piranha:
-                        target.AddBuff(BuffID.Bleeding, Main.rand.Next(60, 600));
-                        break;
-
-                    case NPCID.Medusa:
-                        target.AddBuff(mod.BuffType("Flipped"), Main.rand.Next(90, 180));
-                        if (!target.HasBuff(BuffID.Stoned))
-                            target.AddBuff(BuffID.Stoned, Main.rand.Next(60, 120));
-                        break;
-
-                    case NPCID.SpikeBall:
-                        target.AddBuff(BuffID.BrokenArmor, Main.rand.Next(300, 1200));
-                        if (masoBool[0])
-                            target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(300, 1200));
-                        break;
-
-                    case NPCID.BlazingWheel:
-                        target.AddBuff(BuffID.OnFire, Main.rand.Next(60, 600));
-                        if (masoBool[0])
-                            target.AddBuff(mod.BuffType("FlamesoftheUniverse"), Main.rand.Next(300));
-                        break;
-
-                    case NPCID.Shark:
-                    case NPCID.SandShark:
-                    case NPCID.SandsharkCorrupt:
-                    case NPCID.SandsharkCrimson:
-                    case NPCID.SandsharkHallow:
-                        target.AddBuff(BuffID.Bleeding, Main.rand.Next(60, 300));
-                        break;
-
-                    case NPCID.GraniteFlyer:
-                    case NPCID.GraniteGolem:
-                        if (!target.HasBuff(BuffID.Stoned) && Main.rand.Next(2) == 0)
-                            target.AddBuff(BuffID.Stoned, Main.rand.Next(120));
-                        break;
-
-                    case NPCID.LeechHead:
-                        target.AddBuff(mod.BuffType("Crippled"), Main.rand.Next(300, 900));
-                        target.AddBuff(BuffID.Bleeding, Main.rand.Next(300, 900));
-                        target.AddBuff(BuffID.Rabies, Main.rand.Next(300, 900));
-                        break;
-
-                    case NPCID.AnomuraFungus:
-                        target.AddBuff(BuffID.Poisoned, Main.rand.Next(300, 600));
-                        break;
-
-                    case NPCID.WaterSphere:
-                        target.AddBuff(mod.BuffType("Flipped"), Main.rand.Next(600));
-			            target.AddBuff(BuffID.Wet, Main.rand.Next(1200));
-                        break;
-
-                    case NPCID.GiantShelly:
-                    case NPCID.GiantShelly2:
-                        target.AddBuff(BuffID.Slow, Main.rand.Next(30, 300));
-                        break;
-
-                    case NPCID.Squid:
-                        target.AddBuff(BuffID.Obstructed, Main.rand.Next(30, 300));
-                        break;
-
-                    case NPCID.BloodZombie:
-                        target.AddBuff(BuffID.Cursed, Main.rand.Next(240, 480));
-                        break;
-
-                    case NPCID.Drippler:
-                        target.AddBuff(mod.BuffType("Rotting"), Main.rand.Next(300, 600));
-                        break;
-
-                    case NPCID.ChaosBall:
-                        target.AddBuff(BuffID.ShadowFlame, Main.rand.Next(60, 600));
-                        break;
-
-                    case NPCID.Tumbleweed:
-                        target.AddBuff(mod.BuffType("Crippled"), Main.rand.Next(60, 300));
-                        break;
-
-                    case NPCID.CorruptBunny:
-                    case NPCID.CrimsonBunny:
-                    case NPCID.CorruptGoldfish:
-                    case NPCID.CrimsonGoldfish:
-                    case NPCID.CorruptPenguin:
-                    case NPCID.CrimsonPenguin:
-                    case NPCID.MothronSpawn:
-                    case NPCID.PigronCorruption:
-                    case NPCID.PigronCrimson:
-                    case NPCID.PigronHallow:
-                    case NPCID.Scutlix:
-                    case NPCID.Parrot:
-                    case NPCID.GingerbreadMan:
-                        target.AddBuff(mod.BuffType("SqueakyToy"), Main.rand.Next(300));
-                        break;
-
-                    case NPCID.FaceMonster:
-                        target.AddBuff(BuffID.Rabies, Main.rand.Next(1800));
-                        break;
-
-                    case NPCID.Harpy:
-                        target.AddBuff(mod.BuffType("ClippedWings"), Main.rand.Next(60, 600));
-                        break;
-
-                    case NPCID.SeaSnail:
-                        target.AddBuff(BuffID.OgreSpit, Main.rand.Next(300));
-                        break;
-
-                    case NPCID.BrainofCthulhu:
-                        target.AddBuff(mod.BuffType("Hexed"), Main.rand.Next(90));
-                        target.AddBuff(mod.BuffType("ClippedWings"), Main.rand.Next(300));
-                        target.AddBuff(mod.BuffType("Infested"), Main.rand.Next(300));
-                        target.AddBuff(mod.BuffType("Flipped"), Main.rand.Next(180));
-                        target.AddBuff(BuffID.Rabies, Main.rand.Next(900, 1800));
-                        break;
-
-                    case NPCID.Creeper:
-                        switch (Main.rand.Next(6))
-                        {
-                            case 0:
-                                target.AddBuff(mod.BuffType("Berserked"), Main.rand.Next(240));
-                                break;
-
-                            case 1:
-                                target.AddBuff(mod.BuffType("Lethargic"), Main.rand.Next(240));
-                                break;
-
-                            case 2:
-                                target.AddBuff(mod.BuffType("Flipped"), Main.rand.Next(240));
-                                break;
-
-                            case 3:
-                                target.AddBuff(mod.BuffType("Infested"), Main.rand.Next(240));
-                                break;
-
-                            case 4:
-                                target.AddBuff(mod.BuffType("Rotting"), Main.rand.Next(240));
-                                break;
-
-                            case 5:
-                                target.AddBuff(BuffID.Rabies, Main.rand.Next(900));
-                                break;
-                        }
-                        break;
-
-                    case NPCID.SwampThing:
-                        target.AddBuff(BuffID.OgreSpit, Main.rand.Next(30, 300));
-                        break;
-
-                    case NPCID.Frankenstein:
-                        target.AddBuff(mod.BuffType("LightningRod"), Main.rand.Next(60, 600));
-                        break;
-
-                    case NPCID.Butcher:
-                        target.AddBuff(mod.BuffType("Berserked"), Main.rand.Next(300, 600));
-                        target.AddBuff(BuffID.Bleeding, Main.rand.Next(900, 1800));
-                        break;
-
-                    case NPCID.ThePossessed:
-                        target.AddBuff(mod.BuffType("Hexed"), Main.rand.Next(240));
-                        break;
-
-                    case NPCID.Wolf:
-                        target.AddBuff(mod.BuffType("Crippled"), 300);
-                        target.AddBuff(BuffID.Rabies, Main.rand.Next(1800));
-                        break;
-
-                    case NPCID.Werewolf:
-                        target.AddBuff(BuffID.Rabies, Main.rand.Next(1800));
-                        break;
-
-                    //all armored bones
-                    case 269:
-                    case 270:
-                    case 271:
-                    case 272:
-                    case 273:
-                    case 274:
-                    case 275:
-                    case 276:
-                    case 277:
-                    case 278:
-                    case 279:
-                    case 280: target.AddBuff(mod.BuffType("Bloodthirsty"), Main.rand.Next(90)); break;
-
-                    case NPCID.GiantTortoise:
-                        target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(60, 300));
-                        break;
-
-                    case NPCID.IceTortoise:
-                        target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(60, 300));
-                        if (Main.rand.Next(3) == 0)
-                            target.AddBuff(BuffID.Frozen, Main.rand.Next(120));
-                        break;
-
-                    //CULTIST OP
-                    case NPCID.AncientDoom:
-                        target.AddBuff(mod.BuffType("MarkedforDeath"), 120);
-                        damage *= 3;
-                        break;
-                    case NPCID.AncientLight:
-                        target.AddBuff(mod.BuffType("Purified"), Main.rand.Next(60, 180));
-                        break;
-                    case NPCID.CultistBossClone:
-                        target.AddBuff(mod.BuffType("Hexed"), Main.rand.Next(60, 120));
-                        target.AddBuff(mod.BuffType("CurseoftheMoon"), Main.rand.Next(600, 900));
-                        break;
-
-                    case NPCID.MossHornet:
-                        target.AddBuff(mod.BuffType("Infested"), Main.rand.Next(30, 300));
-                        break;
-
-                    case NPCID.Paladin:
-                        target.AddBuff(mod.BuffType("Lethargic"), Main.rand.Next(480, 720));
-                        break;
-
-                    case NPCID.DukeFishron:
-                        target.AddBuff(mod.BuffType("MutantNibble"), Main.rand.Next(600, 900));
-                        target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(600, 900));
-                        target.AddBuff(BuffID.BrokenArmor, Main.rand.Next(600, 900));
-                        target.AddBuff(BuffID.WitheredArmor, Main.rand.Next(600, 900));
-                        target.AddBuff(BuffID.Rabies, Main.rand.Next(3600, 7200));
-                        target.GetModPlayer<FargoPlayer>(mod).MaxLifeReduction += (npc.whoAmI == fishBossEX) ? 150 : 100;
-                        target.AddBuff(mod.BuffType("OceanicMaul"), Main.rand.Next(3600, 7200));
-                        break;
-
-                    case NPCID.Sharkron:
-                    case NPCID.Sharkron2:
-                        target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(600, 900));
-                        target.AddBuff(mod.BuffType("MutantNibble"), Main.rand.Next(300, 600));
-                        target.AddBuff(BuffID.Rabies, Main.rand.Next(3600, 7200));
-                        if (BossIsAlive(ref fishBossEX, NPCID.DukeFishron))
-                        {
-                            target.GetModPlayer<FargoPlayer>(mod).MaxLifeReduction += 100;
-                            target.AddBuff(mod.BuffType("OceanicMaul"), Main.rand.Next(1800, 3600));
-                        }
-                        break;
-
-                    case NPCID.DetonatingBubble:
-                        target.AddBuff(mod.BuffType("SqueakyToy"), Main.rand.Next(60, 180));
-                        if (BossIsAlive(ref fishBossEX, NPCID.DukeFishron))
-                        {
-                            target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(600, 900));
-                            target.GetModPlayer<FargoPlayer>(mod).MaxLifeReduction += 50;
-                            target.AddBuff(mod.BuffType("OceanicMaul"), Main.rand.Next(1800, 3600));
-                        }
-                        break;
-
-                    case NPCID.Hellhound:
-                        target.AddBuff(BuffID.WitheredWeapon, Main.rand.Next(900));
-                        target.AddBuff(BuffID.Obstructed, Main.rand.Next(180));
-                        break;
-
-                    case NPCID.Mimic:
-                    case NPCID.PresentMimic:
-                        target.AddBuff(mod.BuffType("Purified"), Main.rand.Next(120));
-                        break;
-
-                    case NPCID.BigMimicCorruption:
-                    case NPCID.BigMimicCrimson:
-                    case NPCID.BigMimicHallow:
-                    case NPCID.BigMimicJungle:
-                        target.AddBuff(mod.BuffType("Berserked"), 300);
-                        goto case NPCID.Mimic;
-
-                    case NPCID.RuneWizard:
-                        target.AddBuff(mod.BuffType("MarkedforDeath"), 120);
-                        target.AddBuff(mod.BuffType("Unstable"), 30);
-                        break;
-
-                    case NPCID.Nutcracker:
-                    case NPCID.NutcrackerSpinning:
-                        if (target.Male)
-                        {
-                            damage = 9999;
-                            target.statDefense = 0;
-                            target.endurance = 0;
-                            target.KillMe(PlayerDeathReason.ByCustomReason(target.name + " got his nuts cracked."), 9999, 0);
-                        }
-                        else
-                        {
-                            target.AddBuff(BuffID.Bleeding, Main.rand.Next(900, 1800));
-                        }
-                        break;
-
-                    case NPCID.Wraith:
-                        target.AddBuff(mod.BuffType("LivingWasteland"), Main.rand.Next(300, 900));
-                        break;
-
-                    case NPCID.Plantera:
-                        target.AddBuff(mod.BuffType("MutantNibble"), Main.rand.Next(600, 900));
-                        goto case NPCID.PlanterasHook;
-
-                    case NPCID.PlanterasHook:
-                    case NPCID.PlanterasTentacle:
-                    case NPCID.Spore:
-                        target.AddBuff(BuffID.Poisoned, Main.rand.Next(120, 600));
-                        target.AddBuff(mod.BuffType("Infested"), Main.rand.Next(60, 300));
-                        bool isVenomed = false;
-                        for (int i = 0; i < 22; i++)
-                        {
-                            if (target.buffType[i] == BuffID.Venom && target.buffTime[i] > 1)
-                            {
-                                isVenomed = true;
-                                target.buffTime[i] += Main.rand.Next(60, 180);
-                                if (target.buffTime[i] > 1200)
-                                {
-                                    target.AddBuff(mod.BuffType("Infested"), target.buffTime[i]);
-                                    Main.PlaySound(15, (int)target.Center.X, (int)target.Center.Y, 0);
-                                }
-                                break;
-                            }
-                        }
-                        if (!isVenomed)
-                        {
-                            target.AddBuff(BuffID.Venom, Main.rand.Next(60, 300));
-                        }
-                        break;
-
-                    case NPCID.ChaosElemental:
-                        target.AddBuff(mod.BuffType("Unstable"), Main.rand.Next(600));
-                        break;
-
-                    case NPCID.Flocko:
-                        target.AddBuff(BuffID.Chilled, Main.rand.Next(900, 1800));
-                        target.AddBuff(BuffID.Frostburn, Main.rand.Next(60, 600));
-                        break;
-
-                    case NPCID.GoblinThief:
-                        if (target.whoAmI == Main.myPlayer && Main.rand.Next(2) == 0)
-                        {
-                            //try stealing mouse item, then selected item
-                            if (!StealFromInventory(target, ref Main.mouseItem))
-                                StealFromInventory(target, ref target.inventory[target.selectedItem]);
-
-                            byte extraTries = 30;
-                            for (int i = 0; i < 3; i++)
-                            {
-                                bool successfulSteal = StealFromInventory(target, ref target.inventory[Main.rand.Next(target.inventory.Length)]);
-
-                                if (!successfulSteal && extraTries > 0)
-                                {
-                                    extraTries--;
-                                    i--;
-                                }
-                            }
-                        }
-                        goto case NPCID.PirateCorsair;
-
-                    case NPCID.PirateCaptain:
-                    case NPCID.PirateCorsair:
-                    case NPCID.PirateCrossbower:
-                    case NPCID.PirateDeadeye:
-                    case NPCID.PirateShipCannon:
-                        target.DropCoins();
-                        break;
-
-                    case NPCID.PirateDeckhand:
-                        npc.Transform(NPCID.PirateCaptain);
-                        npc.GetGlobalNPC<FargoGlobalNPC>().dropLoot = false;
-                        target.DropCoins();
-                        goto case NPCID.GrayGrunt;
-
-                    case NPCID.GoblinPeon:
-                    case NPCID.GrayGrunt:
-                        if (Main.hardMode)
-                            target.AddBuff(mod.BuffType("LivingWasteland"), Main.rand.Next(300, 900));
-                        break;
-
-                    case NPCID.Zombie:
-                    case NPCID.ArmedZombie:
-                    case NPCID.ArmedZombieCenx:
-                    case NPCID.ArmedZombiePincussion:
-                    case NPCID.ArmedZombieSlimed:
-                    case NPCID.ArmedZombieSwamp:
-                    case NPCID.ArmedZombieTwiggy:
-                    case NPCID.BaldZombie:
-                    case NPCID.FemaleZombie:
-                    case NPCID.PincushionZombie:
-                    case NPCID.SlimedZombie:
-                    case NPCID.TwiggyZombie:
-                    case NPCID.ZombiePixie:
-                    case NPCID.ZombieRaincoat:
-                    case NPCID.ZombieSuperman:
-                    case NPCID.ZombieSweater:
-                    case NPCID.ZombieXmas:
-                    case NPCID.ZombieMushroom:
-                    case NPCID.ZombieMushroomHat:
-                    case NPCID.SwampZombie:
-                    case NPCID.SmallSwampZombie:
-                    case NPCID.BigSwampZombie:
-                    case NPCID.ZombieDoctor:
-                        target.AddBuff(mod.BuffType("Rotting"), Main.rand.Next(60, 600));
-                        break;
-
-                    case NPCID.ZombieEskimo:
-                    case NPCID.ArmedZombieEskimo:
-                        target.AddBuff(BuffID.Chilled, Main.rand.Next(300));
-                        break;
-
-                    case NPCID.Corruptor:
-                        target.AddBuff(BuffID.Weak, Main.rand.Next(60, 7200));
-			            target.AddBuff(mod.BuffType("Rotting"), Main.rand.Next(300, 3600));
-                        break;
-
-                    case NPCID.Mummy:
-                    case NPCID.LightMummy:
-                    case NPCID.DarkMummy:
-                        if (!target.HasBuff(BuffID.Webbed))
-                            target.AddBuff(BuffID.Webbed, Main.rand.Next(30, 300));
-                        break;
-
-                    case NPCID.Derpling:
-                        target.AddBuff(mod.BuffType("Lethargic"), Main.rand.Next(600, 1200));
-                        break;
-
-                    case NPCID.Spazmatism:
-                        if (masoBool[1] && Main.rand.Next(3) == 0)
-                            target.AddBuff(BuffID.CursedInferno, 480);
-                        break;
-                    /*case NPCID.Retinazer:
-                        target.AddBuff(mod.BuffType("Crippled"), Main.rand.Next(120, 240));
-                        target.AddBuff(mod.BuffType("ClippedWings"), Main.rand.Next(120, 240));
-                        break;*/
-
-                    case NPCID.TheDestroyer:
-                        target.AddBuff(mod.BuffType("Crippled"), Main.rand.Next(300, 1200));
-                        target.AddBuff(mod.BuffType("ClippedWings"), Main.rand.Next(300, 1200));
-                        if (target.statLife < 300)
-                            target.KillMe(PlayerDeathReason.ByCustomReason(target.name + " was eaten alive by the Destroyer."), 9999, 0);
-                        goto case NPCID.TheDestroyerTail;
-
-                    case NPCID.TheDestroyerBody:
-                    case NPCID.TheDestroyerTail:
-                        target.AddBuff(mod.BuffType("LightningRod"), Main.rand.Next(300, 1200));
-                        break;
-
-                    case NPCID.SkeletronPrime:
-                        target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(180, 300));
-                        break;
-
-                    case NPCID.PrimeVice:
-                        if (target.mount.Active)
-                            target.mount.Dismount(target);
-                        target.AddBuff(mod.BuffType("Stunned"), Main.rand.Next(30, 90));
-                        break;
-
-                    /*case NPCID.PrimeCannon:
-                    case NPCID.PrimeLaser:
-                    case NPCID.PrimeSaw:
-                    case NPCID.Probe:
-                        target.AddBuff(mod.BuffType("ClippedWings"), 15); //all mech cases come here
-                        break;*/
-
-                    case NPCID.BlackRecluse:
-                        target.AddBuff(BuffID.Poisoned, Main.rand.Next(30, 300));
-                        target.AddBuff(mod.BuffType("Rotting"), Main.rand.Next(60, 1800));
-                        break;
-
-                    case NPCID.DesertBeast:
-                        target.AddBuff(mod.BuffType("Crippled"), Main.rand.Next(300, 900));
-                        break;
-
-                    case NPCID.FlyingSnake:
-                        target.AddBuff(mod.BuffType("Infested"), Main.rand.Next(300, 600));
-                        target.AddBuff(mod.BuffType("ClippedWings"), Main.rand.Next(600, 1200));
-                        break;
-
-                    case NPCID.Lihzahrd:
-                    case NPCID.LihzahrdCrawler:
-                        target.AddBuff(mod.BuffType("Infested"), Main.rand.Next(60, 300));
-                        target.AddBuff(mod.BuffType("Bloodthirsty"), Main.rand.Next(120));
-                        break;
-
-                    case NPCID.CultistDragonHead:
-                        target.AddBuff(mod.BuffType("CurseoftheMoon"), Main.rand.Next(300, 600));
-                        target.AddBuff(mod.BuffType("ClippedWings"), Main.rand.Next(60, 300));
-                        target.AddBuff(mod.BuffType("MutantNibble"), Main.rand.Next(300, 600));
-                        break;
-                        //goto case NPCID.CultistDragonTail;
-
-                    /*case NPCID.CultistDragonBody1:
-                    case NPCID.CultistDragonBody2:
-                    case NPCID.CultistDragonBody3:
-                    case NPCID.CultistDragonBody4:
-                    case NPCID.CultistDragonTail:
-                        target.AddBuff(mod.BuffType("ClippedWings"), 15);
-                        break;*/
-
-                    case NPCID.AncientCultistSquidhead:
-                        target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(120, 480));
-                        if (Main.rand.Next(2) == 0)
-                            target.AddBuff(mod.BuffType("Flipped"), Main.rand.Next(30, 60));
-                        else
-                            target.AddBuff(mod.BuffType("Unstable"), Main.rand.Next(30, 60));
-                        break;
-
-                    case NPCID.SolarCrawltipedeHead:
-                        target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(600, 1200));
-                        if (target.statLife < 200)
-                            target.KillMe(PlayerDeathReason.ByCustomReason(target.name + " was eaten alive by a Crawltipede."), 999, 0);
-                        break;
-
-                    case NPCID.BoneLee:
-                        target.AddBuff(BuffID.Obstructed, Main.rand.Next(60));
-                        break;
-
-                    case NPCID.Pumpking:
-                    case NPCID.PumpkingBlade:
-                        target.AddBuff(BuffID.Weak, Main.rand.Next(900, 1800));
-                        target.AddBuff(mod.BuffType("Rotting"), Main.rand.Next(900, 1800));
-                        break;
-
-                    case NPCID.MourningWood:
-                        int duration1 = Main.rand.Next(120, 240);
-                        target.AddBuff(BuffID.OnFire, duration1);
-                        target.AddBuff(BuffID.CursedInferno, duration1);
-                        target.AddBuff(BuffID.ShadowFlame, duration1);
-                        break;
-
-                    case NPCID.VortexHornet:
-                    case NPCID.VortexHornetQueen:
-                    case NPCID.VortexSoldier:
-                    case NPCID.VortexRifleman:
-                        target.AddBuff(mod.BuffType("LightningRod"), Main.rand.Next(60, 600));
-                        target.AddBuff(mod.BuffType("ClippedWings"), Main.rand.Next(30, 300));
-                        break;
-
-                    case NPCID.ZombieElf:
-                    case NPCID.ZombieElfBeard:
-                    case NPCID.ZombieElfGirl:
-                        target.AddBuff(mod.BuffType("Rotting"), Main.rand.Next(300, 1800));
-                        break;
-
-                    case NPCID.Krampus:
-                        if (target.whoAmI == Main.myPlayer)
-                        {
-                            //try stealing mouse item, then selected item
-                            if (!StealFromInventory(target, ref Main.mouseItem))
-                                StealFromInventory(target, ref target.inventory[target.selectedItem]);
-
-                            StealFromInventory(target, ref target.armor[Main.rand.Next(3)]);
-
-                            byte maxAttempts = 15;
-                            for (int i = 0; i < 3; i++)
-                            {
-                                int toss = Main.rand.Next(3, 8 + target.extraAccessorySlots); //pick random accessory slot
-                                if (Main.rand.Next(3) == 0 && target.armor[toss + 10].stack > 0) //chance to pick vanity slot if accessory is there
-                                {
-                                    toss += 10;
-                                }
-
-                                bool successfulSteal = StealFromInventory(target, ref target.armor[toss]);
-
-                                if (!successfulSteal && maxAttempts > 0)
-                                {
-                                    maxAttempts--;
-                                    i--;
-                                }
-                            }
-                        }
-                        break;
-
-                    case NPCID.GigaZapper:
-                        target.AddBuff(mod.BuffType("LightningRod"), Main.rand.Next(300, 600));
-                        break;
-
-                    case NPCID.Clown:
-                        target.AddBuff(mod.BuffType("Fused"), 180);
-                        target.AddBuff(mod.BuffType("Hexed"), 1200);
-                        break;
-
-                    case NPCID.UndeadMiner:
-                        int length = Main.rand.Next(3600, 7200);
-                        target.AddBuff(mod.BuffType("Lethargic"), length * 2);
-                        target.AddBuff(BuffID.Blackout, length);
-                        target.AddBuff(BuffID.NoBuilding, length);
-                        for (int i = 0; i < 59; i++)
-                        {
-                            if (target.inventory[i].pick != 0 || target.inventory[i].hammer != 0 || target.inventory[i].axe != 0)
-                                StealFromInventory(target, ref target.inventory[i]);
-                        }
-                        break;
-
-                    case NPCID.Golem:
-                    case NPCID.GolemFistLeft:
-                    case NPCID.GolemFistRight:
-                        target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(300, 600));
-                        target.AddBuff(BuffID.BrokenArmor, Main.rand.Next(60, 300));
-                        break;
-
-                    case NPCID.DD2Betsy:
-                        target.AddBuff(mod.BuffType("MutantNibble"), Main.rand.Next(300, 600));
-                        target.AddBuff(BuffID.Rabies, Main.rand.Next(3600, 7200));
-                        target.AddBuff(BuffID.WitheredArmor, Main.rand.Next(300, 600));
-                        target.AddBuff(BuffID.WitheredWeapon, Main.rand.Next(300, 600));
-                        target.AddBuff(BuffID.Ichor, Main.rand.Next(600, 900));
-                        target.AddBuff(BuffID.OnFire, Main.rand.Next(900, 1800));
-                        break;
-
-                    case NPCID.DD2WyvernT1:
-                    case NPCID.DD2WyvernT2:
-                    case NPCID.DD2WyvernT3:
-                        target.AddBuff(mod.BuffType("MutantNibble"), Main.rand.Next(300, 600));
-                        target.AddBuff(BuffID.Rabies, Main.rand.Next(3600, 7200));
-                        break;
-
-                    case NPCID.DD2KoboldFlyerT2:
-                    case NPCID.DD2KoboldFlyerT3:
-                    case NPCID.DD2KoboldWalkerT2:
-                    case NPCID.DD2KoboldWalkerT3:
-                        target.AddBuff(mod.BuffType("Fused"), 1800);
-                        break;
-
-                    case NPCID.DD2OgreT2:
-                    case NPCID.DD2OgreT3:
-                        target.AddBuff(mod.BuffType("Stunned"), Main.rand.Next(30, 60));
-                        target.AddBuff(mod.BuffType("Defenseless"), Main.rand.Next(180, 300));
-                        target.AddBuff(BuffID.BrokenArmor, Main.rand.Next(300, 600));
-                        break;
-
-                    case NPCID.DD2LightningBugT3:
-                        target.AddBuff(BuffID.Electrified, Main.rand.Next(300, 600));
-                        break;
-
-                    case NPCID.DD2SkeletonT1:
-                    case NPCID.DD2SkeletonT3:
-                        target.AddBuff(BuffID.ShadowFlame, Main.rand.Next(300, 600));
-                        target.AddBuff(mod.BuffType("Rotting"), Main.rand.Next(1200, 2400));
-                        break;
-
-                    case NPCID.SolarSpearman:
-                    case NPCID.SolarSroller:
-                        target.AddBuff(BuffID.OnFire, Main.rand.Next(300, 600));
-                        target.AddBuff(BuffID.Burning, Main.rand.Next(60, 300));
-                        break;
-
-                    case NPCID.SolarSolenian:
-                        target.AddBuff(BuffID.OnFire, Main.rand.Next(300, 600));
-                        target.AddBuff(BuffID.Ichor, Main.rand.Next(600, 1200));
-                        break;
-
-                    case NPCID.SolarDrakomire:
-                    case NPCID.SolarDrakomireRider:
-                        target.AddBuff(BuffID.OnFire, Main.rand.Next(300, 600));
-                        target.AddBuff(BuffID.Rabies, Main.rand.Next(7200));
-                        break;
-
-                    case NPCID.DesertScorpionWalk:
-                    case NPCID.DesertScorpionWall:
-                    case NPCID.MisterStabby:
-                        target.AddBuff(mod.BuffType("MarkedforDeath"), Main.rand.Next(60, 180));
-                        break;
-
-                    case NPCID.NebulaHeadcrab:
-                        target.AddBuff(mod.BuffType("Unstable"), Main.rand.Next(60, 180));
-                        target.AddBuff(mod.BuffType("Flipped"), Main.rand.Next(60, 180));
-                        break;
-
-                    case NPCID.StardustCellBig:
-                    case NPCID.StardustCellSmall:
-                        target.AddBuff(mod.BuffType("SqueakyToy"), Main.rand.Next(60, 180));
-                        break;
-
-                    case NPCID.StardustWormHead:
-                    case NPCID.StardustWormBody:
-                    case NPCID.StardustWormTail:
-                        target.AddBuff(mod.BuffType("Berserked"), Main.rand.Next(60, 300));
-                        break;
-
-                    case NPCID.StardustSpiderBig:
-                    case NPCID.StardustSpiderSmall:
-                        target.AddBuff(BuffID.Frostburn, Main.rand.Next(300, 600));
-                        break;
-
-                    case NPCID.MoonLordFreeEye:
-                    case NPCID.MoonLordHand:
-                    case NPCID.MoonLordHead:
-                        target.AddBuff(mod.BuffType("CurseoftheMoon"), 600);
-                        break;
-			
-		            case NPCID.BoneSerpentHead:
-			            target.AddBuff(BuffID.Burning, Main.rand.Next(300, 600));
-			            break;
-			
-		            case NPCID.Salamander:
-                    case NPCID.Salamander2:
-                    case NPCID.Salamander3:
-                    case NPCID.Salamander4:
-                    case NPCID.Salamander5:
-                    case NPCID.Salamander6:
-                    case NPCID.Salamander7:
-                    case NPCID.Salamander8:
-                    case NPCID.Salamander9:
-			            target.AddBuff(BuffID.Poisoned, Main.rand.Next(600, 900));
-			            break;
-			
-		            case NPCID.VileSpit:
-			            target.AddBuff(mod.BuffType("Rotting"), Main.rand.Next(240, 360));
-			            break;
+                    
 
                     default:
                         break;
                 }
-            }
+            }*/
            
             if(target.HasBuff(mod.BuffType("ShellHide")))
                 damage *= 2;

--- a/Projectiles/FargoGlobalProjectile.cs
+++ b/Projectiles/FargoGlobalProjectile.cs
@@ -780,9 +780,28 @@ namespace FargowiltasSouls.Projectiles
 
         public override void ModifyHitPlayer(Projectile projectile, Player target, ref int damage, ref bool crit)
         {
-            //Player player = Main.player[Main.myPlayer];
-            FargoPlayer modPlayer = target.GetModPlayer<FargoPlayer>(mod);
+            //FargoPlayer modPlayer = target.GetModPlayer<FargoPlayer>(mod);
 
+            /*if (FargoWorld.MasochistMode)
+            {
+                switch(projectile.type)
+                {
+                    
+
+                    default:
+                        break;
+                }
+            }*/
+
+            if(squeakyToy)
+            {
+                damage = 1;
+                target.GetModPlayer<FargoPlayer>().Squeak(target.Center);
+            }
+        }
+
+        public override void OnHitPlayer(Projectile projectile, Player target, int damage, bool crit)
+        {
             if (FargoWorld.MasochistMode)
             {
                 switch(projectile.type)
@@ -793,7 +812,7 @@ namespace FargowiltasSouls.Projectiles
                         break;
 
                     case ProjectileID.DemonSickle:
-                        if(IsRecolor)
+                        if (IsRecolor)
                         {
                             target.AddBuff(BuffID.ShadowFlame, 300);
                             target.AddBuff(BuffID.Bleeding, 600);
@@ -803,7 +822,7 @@ namespace FargowiltasSouls.Projectiles
                             target.AddBuff(BuffID.Darkness, Main.rand.Next(900, 1800));
                             target.AddBuff(BuffID.ShadowFlame, Main.rand.Next(300, 600));
                         }
-                        
+
                         break;
 
                     case ProjectileID.HarpyFeather:
@@ -820,7 +839,7 @@ namespace FargowiltasSouls.Projectiles
                     case ProjectileID.Stinger:
                         if (FargoGlobalNPC.BossIsAlive(ref FargoGlobalNPC.beeBoss, NPCID.QueenBee))
                             target.AddBuff(BuffID.Venom, Main.rand.Next(180, 900));
-                            target.AddBuff(BuffID.BrokenArmor, Main.rand.Next(120, 1200));
+                        target.AddBuff(BuffID.BrokenArmor, Main.rand.Next(120, 1200));
                         break;
 
                     case ProjectileID.Skull:
@@ -1113,11 +1132,6 @@ namespace FargowiltasSouls.Projectiles
                     default:
                         break;
                 }
-            }
-
-            if(squeakyToy)
-            {
-                modPlayer.Squeak(target.Center);
             }
         }
 

--- a/masomode stuff to test again.txt
+++ b/masomode stuff to test again.txt
@@ -12,6 +12,12 @@
 //	default type = 82 (flaming arrow?)
 //	default damage = 35
 //	default expertmode damage: *= 0.80
+-fishron EX stats don't benefit from fishrons killed until fishron EX has been killed
+-rearranged stuff, mainly moving debuffs from modifyhitplayer to onhitplayer
+-sharkrons and bubbles scale with defeated fishrons
+-oceanic maul no longer removes knockback resistance
+-buff reinforced plating/dubious circuitry/maso soul to give knockback immunity
+-add a shrimpy truffle to truffle worm EX recipe
 -flames of universe gives immunity to npcs against its components
 -did something to force new sadism debuff onto enemies
 -changed how oceanic maul/curse of moon reduce defense (i think it went negative previously)


### PR DESCRIPTION
… has been killed

-rearranged stuff, mainly moving debuffs from modifyhitplayer to onhitplayer
-sharkrons and bubbles scale with defeated fishrons
-oceanic maul no longer removes knockback resistance
-buff reinforced plating/dubious circuitry/maso soul to give knockback immunity
-add a shrimpy truffle to truffle worm EX recipe