### PR TITLE
Rod of Discord autouse fix

### DIFF
--- a/FargoPlayer.cs
+++ b/FargoPlayer.cs
@@ -4866,7 +4866,7 @@ namespace FargowiltasSouls
 
         public override bool PreItemCheck()
         {
-            if (TribalCharm && SoulConfig.Instance.TribalCharm)
+            if (TribalCharm && SoulConfig.Instance.TribalCharm && player.HeldItem.type != ItemID.RodofDiscord)
             {
                 TribalAutoFire = player.HeldItem.autoReuse;
                 player.HeldItem.autoReuse = true;
@@ -4883,7 +4883,7 @@ namespace FargowiltasSouls
 
         public override void PostItemCheck()
         {
-            if (TribalCharm && SoulConfig.Instance.TribalCharm)
+            if (TribalCharm && SoulConfig.Instance.TribalCharm && player.HeldItem.type != ItemID.RodofDiscord)
             {
                 player.HeldItem.autoReuse = TribalAutoFire;
             }


### PR DESCRIPTION
Tribal charm makes an exception for rod of discord that makes it not have autouse. This makes using the rod hotkey a lot easier.