### PR TITLE
Tweaks to Deviantt Energy Heart

### DIFF
--- a/Projectiles/DeviBoss/DeviEnergyHeart.cs
+++ b/Projectiles/DeviBoss/DeviEnergyHeart.cs
@@ -26,7 +26,7 @@ namespace FargowiltasSouls.Projectiles.DeviBoss
             projectile.aiStyle = -1;
             cooldownSlot = 1;
 
-            projectile.alpha = 125;
+            projectile.alpha = 150;
             projectile.timeLeft = 90;
 
             projectile.GetGlobalProjectile<FargoGlobalProjectile>().ImmuneToGuttedHeart = true;
@@ -45,7 +45,12 @@ namespace FargowiltasSouls.Projectiles.DeviBoss
                 Main.PlaySound(SoundID.Item44, projectile.Center);
             }
 
+            // Fade into 50 alpha from 150
+            if (projectile.alpha >= 60)
+                projectile.alpha -= 10;
+
             projectile.rotation = projectile.ai[0];
+            projectile.scale += 0.01f;
 
             float speed = projectile.velocity.Length();
             speed += projectile.ai[1];
@@ -79,33 +84,6 @@ namespace FargowiltasSouls.Projectiles.DeviBoss
             target.AddBuff(mod.BuffType("Lovestruck"), 240);
         }
 
-        public override Color? GetAlpha(Color lightColor)
-        {
-            return Color.White * projectile.Opacity;
-        }
-
-        public override bool PreDraw(SpriteBatch spriteBatch, Color lightColor)
-        {
-            Texture2D texture2D13 = Main.projectileTexture[projectile.type];
-            int num156 = Main.projectileTexture[projectile.type].Height / Main.projFrames[projectile.type]; //ypos of lower right corner of sprite to draw
-            int y3 = num156 * projectile.frame; //ypos of upper left corner of sprite to draw
-            Rectangle rectangle = new Rectangle(0, y3, texture2D13.Width, num156);
-            Vector2 origin2 = rectangle.Size() / 2f;
-
-            Color color26 = lightColor;
-            color26 = projectile.GetAlpha(color26);
-
-            for (int i = 0; i < ProjectileID.Sets.TrailCacheLength[projectile.type]; i += 2)
-            {
-                Color color27 = color26;
-                color27 *= (float)(ProjectileID.Sets.TrailCacheLength[projectile.type] - i) / ProjectileID.Sets.TrailCacheLength[projectile.type];
-                Vector2 value4 = projectile.oldPos[i];
-                float num165 = projectile.oldRot[i];
-                Main.spriteBatch.Draw(texture2D13, value4 + projectile.Size / 2f - Main.screenPosition + new Vector2(0, projectile.gfxOffY), new Microsoft.Xna.Framework.Rectangle?(rectangle), color27, num165, origin2, projectile.scale, SpriteEffects.None, 0f);
-            }
-
-            Main.spriteBatch.Draw(texture2D13, projectile.Center - Main.screenPosition + new Vector2(0f, projectile.gfxOffY), new Microsoft.Xna.Framework.Rectangle?(rectangle), projectile.GetAlpha(lightColor), projectile.rotation, origin2, projectile.scale, SpriteEffects.None, 0f);
-            return false;
-        }
+        public override Color? GetAlpha(Color lightColor) => Color.White * projectile.Opacity;
     }
 }


### PR DESCRIPTION
Deviantt Energy hearts now:
* Are full bright once fully deployed
* Fade in instead of having a lower opacity
* Expand as they charge
The former two are to improve visibility, the latter for a bit more telegraphing.