### PR TITLE
Added Modded-Vanilla Boss Loot to Boss Checklist & Moved Boss Check Checklist ModCalls to a ModCompat-Extending Class

### DIFF
--- a/Fargowiltas.cs
+++ b/Fargowiltas.cs
@@ -25,6 +25,7 @@ using Fargowiltas.Items.Tiles;
 using Fargowiltas.Items.Explosives;
 using Microsoft.Xna.Framework.Graphics;
 using FargowiltasSouls.Items.Dyes;
+using FargowiltasSouls.Items.Misc;
 
 namespace FargowiltasSouls
 {
@@ -97,8 +98,6 @@ namespace FargowiltasSouls
             AddToggle("PatreonKingSlime", "Medallion of the Fallen King", "MedallionoftheFallenKing", "ffffff");
             AddToggle("PatreonFishron", "Staff Of Unleashed Ocean", "StaffOfUnleashedOcean", "ffffff");
             AddToggle("PatreonPlant", "Piranha Plant Voodoo Doll", "PiranhaPlantVoodooDoll", "ffffff");
-
-
 
             AddToggle("WoodHeader", "Force of Timber", "TimberForce", "ffffff");
             AddToggle("BorealConfig", "Boreal Snowballs", "BorealWoodEnchant", "8B7464");
@@ -187,7 +186,7 @@ namespace FargowiltasSouls
             AddToggle("VortexSConfig", "Vortex Stealth", "VortexEnchant", "00f2aa");
             AddToggle("VortexVConfig", "Vortex Voids", "VortexEnchant", "00f2aa");
 
-            #endregion
+            #endregion enchants
 
             #region masomode toggles
 
@@ -208,7 +207,7 @@ namespace FargowiltasSouls
             AddToggle("MasoHoneyConfig", "Honey When Hitting Enemies", "QueenStinger", "ffffff");
             AddToggle("MasoSkeleConfig", "Skeletron Arms Minion", "NecromanticBrew", "ffffff");
 
-            //bionomic 
+            //bionomic
             AddToggle("BionomicHeader", "Bionomic Cluster", "BionomicCluster", "ffffff");
             AddToggle("MasoConcoctionConfig", "Tim's Concoction", "TimsConcoction", "ffffff");
             AddToggle("MasoCarrotConfig", "Carrot View", "OrdinaryCarrot", "ffffff");
@@ -221,7 +220,7 @@ namespace FargowiltasSouls
             AddToggle("TribalCharmConfig", "Tribal Charm Auto Swing", "TribalCharm", "ffffff");
             //AddToggle("WalletHeader", "Security Wallet", "SecurityWallet", "ffffff");
 
-            //dubious 
+            //dubious
             AddToggle("DubiousHeader", "Dubious Circuitry", "DubiousCircuitry", "ffffff");
             AddToggle("MasoLightningConfig", "Inflict Lightning Rod", "GroundStick", "ffffff");
             AddToggle("MasoProbeConfig", "Probes Minion", "GroundStick", "ffffff");
@@ -235,7 +234,7 @@ namespace FargowiltasSouls
             AddToggle("LumpofFleshHeader", "Lump of Flesh", "LumpOfFlesh", "ffffff");
             AddToggle("MasoPugentConfig", "Pungent Eye Minion", "LumpOfFlesh", "ffffff");
 
-            //chalice 
+            //chalice
             AddToggle("ChaliceHeader", "Chalice of the Moon", "ChaliceoftheMoon", "ffffff");
             AddToggle("MasoCultistConfig", "Cultist Minion", "ChaliceoftheMoon", "ffffff");
             AddToggle("MasoPlantConfig", "Plantera Minion", "MagicalBulb", "ffffff");
@@ -263,7 +262,7 @@ namespace FargowiltasSouls
             AddToggle("MasoRingConfig", "Phantasmal Ring Minion", "MutantMask", "ffffff");
             AddToggle("MasoReviveDeathrayConfig", "Deathray When Revived", "MutantMask", "ffffff");
 
-            #endregion
+            #endregion masomode toggles
 
             #region soul toggles
 
@@ -291,7 +290,7 @@ namespace FargowiltasSouls
             AddToggle("TrawlerConfig", "Trawler Extra Lures", "TrawlerSoul", "ffffff");
             AddToggle("EternityConfig", "Eternity Stacking", "EternitySoul", "ffffff");
 
-            #endregion
+            #endregion soul toggles
 
             #region pet toggles
 
@@ -329,19 +328,18 @@ namespace FargowiltasSouls
             AddToggle("PetSuspEyeConfig", "Suspicious Eye Pet", 3577, "ffffff");
             AddToggle("PetWispConfig", "Wisp Pet", 1183, "ffffff");
 
-            #endregion
+            #endregion pet toggles
 
-            #endregion
-
+            #endregion Toggles
 
             if (Main.netMode != NetmodeID.Server)
             {
                 #region shaders
+
                 //loading refs for shaders
                 Ref<Effect> lcRef = new Ref<Effect>(GetEffect("Effects/LifeChampionShader"));
                 Ref<Effect> wcRef = new Ref<Effect>(GetEffect("Effects/WillChampionShader"));
                 Ref<Effect> gaiaRef = new Ref<Effect>(GetEffect("Effects/GaiaShader"));
-
 
                 //loading shaders from refs
                 GameShaders.Misc["LCWingShader"] = new MiscShaderData(lcRef, "LCWings");
@@ -353,9 +351,8 @@ namespace FargowiltasSouls
                 GameShaders.Misc["GaiaShader"] = new MiscShaderData(gaiaRef, "GaiaGlow");
                 GameShaders.Armor.BindShader(ModContent.ItemType<GaiaDye>(), new ArmorShaderData(gaiaRef, "GaiaArmor").UseColor(new Color(0.44f, 1, 0.09f)).UseSecondaryColor(new Color(0.5f, 1f, 0.9f)));
 
-                #endregion
+                #endregion shaders
             }
-
         }
 
         public void AddToggle(String toggle, String name, String item, String color)
@@ -435,7 +432,6 @@ namespace FargowiltasSouls
                     case "MutantDiscountCard":
                         return Main.LocalPlayer.GetModPlayer<FargoPlayer>().MutantsDiscountCard;
 
-
                     /*case "DevianttGifts":
 
                         Player player = Main.LocalPlayer;
@@ -466,8 +462,6 @@ namespace FargowiltasSouls
                         FargoPlayer fargoPlayer = player.GetModPlayer<FargoPlayer>();
                         return fargoPlayer.ReceivedMasoGift;
 
-                        
-
                     case "GiveDevianttGifts":
                         Player player2 = Main.LocalPlayer;
                         FargoPlayer fargoPlayer2 = player2.GetModPlayer<FargoPlayer>();
@@ -487,9 +481,7 @@ namespace FargowiltasSouls
                         //Main.npcChatText = "This world looks tougher than usual, so you can have these on the house just this once! Talk to me if you need any tips, yeah?";
 
                         break;
-
                 }
-
             }
             catch (Exception e)
             {
@@ -524,7 +516,7 @@ namespace FargowiltasSouls
                 Item.NewItem(player.Center, ModLoader.GetMod("MagicStorage").ItemType("StorageUnit"), 16);
 
                 FargoSoulsWorld.ReceivedTerraStorage = true;
-                if (Main.netMode != 0)
+                if (Main.netMode != NetmodeID.SinglePlayer)
                     NetMessage.SendData(MessageID.WorldData); //sync world in mp
             }
         }
@@ -604,10 +596,11 @@ namespace FargowiltasSouls
                 Mod musicMod = ModLoader.GetMod("FargowiltasMusic");
                 if (bossChecklist != null)
                 {
+                    // Add Souls boss information
                     bossChecklist.Call(
                         "AddBoss",
                         5.01f,
-                        ModContent.NPCType<NPCs.DeviBoss.DeviBoss>(),
+                        ModContent.NPCType<DeviBoss>(),
                         this,
                         "Deviantt",
                         (Func<bool>)(() => FargoSoulsWorld.downedDevi),
@@ -817,7 +810,7 @@ namespace FargowiltasSouls
                     bossChecklist.Call(
                         "AddBoss",
                         14.01f,
-                        ModContent.NPCType<NPCs.AbomBoss.AbomBoss>(),
+                        ModContent.NPCType<AbomBoss>(),
                         this,
                         "Abominationn",
                         (Func<bool>)(() => FargoSoulsWorld.downedAbom),
@@ -847,42 +840,72 @@ namespace FargowiltasSouls
                     );*/
                     //bossChecklist.Call("AddBossWithInfo", "Duke Fishron EX", 14.02f, (Func<bool>)(() => FargoSoulsWorld.downedFishronEX), "Fish using a [i:" + ItemType("TruffleWormEX") + "]");
                     if (ModLoader.GetMod("CalamityMod") != null)
-		            {
+                    {
+                        bossChecklist.Call(
+                            "AddBoss",
+                            20.0f,
+                            ModContent.NPCType<MutantBoss>(),
+                            this,
+                            "Mutant",
+                            (Func<bool>)(() => FargoSoulsWorld.downedMutant),
+                            ModContent.ItemType<Items.Summons.AbominationnVoodooDoll>(),
+                            musicMod != null ? new List<int> { ModContent.ItemType<Items.Tiles.MutantTrophy>(), musicMod.ItemType("MutantMusicBox") }
+                            : new List<int> { ModContent.ItemType<Items.Tiles.MutantTrophy>() },
+                            ModContent.ItemType<Items.Misc.Sadism>(),
+                            "Throw [i:" + ModContent.ItemType<Items.Summons.AbominationnVoodooDoll>() + "] into a pool of lava while Abominationn is alive, in Mutant's presence.",
+                            "Mutant has eviscerated everyone under its hands.",
+                            "FargowiltasSouls/NPCs/MutantBoss/MutantBoss_Still",
+                            "FargowiltasSouls/NPCs/MutantBoss/MutantBoss_Head_Boss"
+                        );
+                    }
+                    else
+                    {
+                        bossChecklist.Call(
+                            "AddBoss",
+                            14.03f,
+                            ModContent.NPCType<MutantBoss>(),
+                            this,
+                            "Mutant",
+                            (Func<bool>)(() => FargoSoulsWorld.downedMutant),
+                            ModContent.ItemType<Items.Summons.AbominationnVoodooDoll>(),
+                            musicMod != null ? new List<int> { ModContent.ItemType<Items.Tiles.MutantTrophy>(), musicMod.ItemType("MutantMusicBox") }
+                            : new List<int> { ModContent.ItemType<Items.Tiles.MutantTrophy>() },
+                            ModContent.ItemType<Items.Misc.Sadism>(),
+                            "Throw [i:" + ModContent.ItemType<Items.Summons.AbominationnVoodooDoll>() + "] into a pool of lava while Abominationn is alive, in Mutant's presence.",
+                            "Mutant has eviscerated everyone under its hands.",
+                            "FargowiltasSouls/NPCs/MutantBoss/MutantBoss_Still",
+                            "FargowiltasSouls/NPCs/MutantBoss/MutantBoss_Head_Boss"
+                        );
+                    }
 
-			        bossChecklist.Call(
-                        "AddBoss",
-                        20.0f,
-                        ModContent.NPCType<NPCs.MutantBoss.MutantBoss>(),
-			            this,
-			            "Mutant",
-			            (Func<bool>)(() => FargoSoulsWorld.downedMutant),
-			            ModContent.ItemType<Items.Summons.AbominationnVoodooDoll>(),
-                        musicMod != null ? new List<int> { ModContent.ItemType<Items.Tiles.MutantTrophy>(), musicMod.ItemType("MutantMusicBox") }
-                        : new List<int> { ModContent.ItemType<Items.Tiles.MutantTrophy>() },
-			            ModContent.ItemType<Items.Misc.Sadism>(),
-			            "Throw [i:" + ModContent.ItemType<Items.Summons.AbominationnVoodooDoll>() + "] into a pool of lava while Abominationn is alive, in Mutant's presence.",
-			            "Mutant has eviscerated everyone under its hands.",
-			            "FargowiltasSouls/NPCs/MutantBoss/MutantBoss_Still",
-			            "FargowiltasSouls/NPCs/MutantBoss/MutantBoss_Head_Boss"
-                    );
-		            } else {
-			        bossChecklist.Call(
-                        "AddBoss",
-                        14.03f,
-                        ModContent.NPCType<NPCs.MutantBoss.MutantBoss>(),
-			            this,
-			            "Mutant",
-			            (Func<bool>)(() => FargoSoulsWorld.downedMutant),
-			            ModContent.ItemType<Items.Summons.AbominationnVoodooDoll>(),
-                        musicMod != null ? new List<int> { ModContent.ItemType<Items.Tiles.MutantTrophy>(), musicMod.ItemType("MutantMusicBox") }
-                        : new List<int> { ModContent.ItemType<Items.Tiles.MutantTrophy>() },
-			            ModContent.ItemType<Items.Misc.Sadism>(),
-			            "Throw [i:" + ModContent.ItemType<Items.Summons.AbominationnVoodooDoll>() + "] into a pool of lava while Abominationn is alive, in Mutant's presence.",
-			            "Mutant has eviscerated everyone under its hands.",
-			            "FargowiltasSouls/NPCs/MutantBoss/MutantBoss_Still",
-			            "FargowiltasSouls/NPCs/MutantBoss/MutantBoss_Head_Boss"
-                    );
-		            }
+                    // Add vanilla boss information
+                    bossChecklist.Call("AddToBossLoot", "Terraria", "PirateShip", new List<int> { ModContent.ItemType<SecurityWallet>() }); // Coin gun & lucky coin are already dropped
+                    bossChecklist.Call("AddToBossLoot", "Terraria", "MourningWood", new List<int> { ItemID.BloodyMachete });
+                    bossChecklist.Call("AddToBossLoot", "Terraria", "Pumpking", new List<int> { ItemID.BladedGlove, ModContent.ItemType<PumpkingsCape>() });
+                    bossChecklist.Call("AddToBossLoot", "Terraria", "IceQueen", new List<int> { ModContent.ItemType<IceQueensCrown>() });
+                    bossChecklist.Call("AddToBossLoot", "Terraria", "MartianSaucerCore", new List<int> { ModContent.ItemType<SaucerControlConsole>() });
+
+                    // Should we shoe presents? They contribute virtually nothing
+                    bossChecklist.Call("AddToBossLoot", "Terraria", "Everscream", new List<int> { ItemID.Present }); // TODO: Extension methods to reduce boilerplate
+                    bossChecklist.Call("AddToBossLoot", "Terraria", "SantaNK1", new List<int> { ItemID.Present });
+
+                    // Only include important drops, crates and stuff hardly matter
+                    bossChecklist.Call("AddToBossLoot", "Terraria", "KingSlime", new List<int> { ModContent.ItemType<SlimyShield>() });
+                    bossChecklist.Call("AddToBossLoot", "Terraria", "EyeofCthulhu", new List<int> { ModContent.ItemType<AgitatingLens>() });
+                    bossChecklist.Call("AddToBossLoot", "Terraria", "EaterofWorldsHead", new List<int> { ModContent.ItemType<CorruptHeart>() });
+                    bossChecklist.Call("AddToBossLoot", "Terraria", "BrainofCthulhu", new List<int> { ModContent.ItemType<GuttedHeart>() });
+                    bossChecklist.Call("AddToBossLoot", "Terraria", "SkeletronHead", new List<int> { ModContent.ItemType<NecromanticBrew>() });
+                    bossChecklist.Call("AddToBossLoot", "Terraria", "QueenBee", new List<int> { ModContent.ItemType<QueenStinger>() });
+                    bossChecklist.Call("AddToBossLoot", "Terraria", "WallofFlesh", new List<int> { ModContent.ItemType<PungentEyeball>(), ModContent.ItemType<MutantsDiscountCard>() });
+                    bossChecklist.Call("AddToBossLoot", "Terraria", "TheTwins", new List<int> { ModContent.ItemType<FusedLens>() });
+                    bossChecklist.Call("AddToBossLoot", "Terraria", "TheDestroyer", new List<int> { ModContent.ItemType<GroundStick>() });
+                    bossChecklist.Call("AddToBossLoot", "Terraria", "SkeletronPrime", new List<int> { ModContent.ItemType<ReinforcedPlating>() });
+                    bossChecklist.Call("AddToBossLoot", "Terraria", "Plantera", new List<int> { ModContent.ItemType<MagicalBulb>() });
+                    bossChecklist.Call("AddToBossLoot", "Terraria", "Golem", new List<int> { ModContent.ItemType<LihzahrdTreasureBox>() });
+                    bossChecklist.Call("AddToBossLoot", "Terraria", "DD2Betsy", new List<int> { ModContent.ItemType<BetsysHeart>() });
+                    bossChecklist.Call("AddToBossLoot", "Terraria", "DukeFishron", new List<int> { ModContent.ItemType<MutantAntibodies>(), ModContent.ItemType<MutantsPact>() });
+                    bossChecklist.Call("AddToBossLoot", "Terraria", "CultistBoss", new List<int> { ModContent.ItemType<CelestialRune>(), ModContent.ItemType<CelestialSeal>() });
+                    bossChecklist.Call("AddToBossLoot", "Terraria", "MoonLord", new List<int> { ModContent.ItemType<GalacticGlobe>() });
                 }
                 //mutant shop
                 Mod fargos = ModLoader.GetMod("Fargowiltas");
@@ -893,12 +916,9 @@ namespace FargowiltasSouls
             }
             catch (Exception e)
             {
-                ErrorLogger.Log("FargowiltasSouls PostSetupContent Error: " + e.StackTrace + e.Message);
+                Logger.Warn("FargowiltasSouls PostSetupContent Error: " + e.StackTrace + e.Message);
             }
         }
-
-        
-
 
         public override void AddRecipes()
         {
@@ -1163,7 +1183,7 @@ namespace FargowiltasSouls
                     break;
 
                 case 11: //refresh creeper
-                    if (Main.netMode != 0)
+                    if (Main.netMode != NetmodeID.SinglePlayer)
                     {
                         byte player = reader.ReadByte();
                         NPC creeper = Main.npc[reader.ReadByte()];
@@ -1199,7 +1219,7 @@ namespace FargowiltasSouls
                         limb.Counter[1] = reader.ReadInt32();
                     }
                     break;
-                    
+
                 case 14: //devi gifts
                     if (Main.netMode == NetmodeID.Server)
                     {
@@ -1341,7 +1361,6 @@ namespace FargowiltasSouls
             return NormalSpawn(spawnInfo) && NoBiome(spawnInfo) && NoZone(spawnInfo);
         }
 
-
         #region Compatibilities
 
         internal CalamityCompatibility CalamityCompatibility { get; private set; }
@@ -1356,10 +1375,10 @@ namespace FargowiltasSouls
         internal MasomodeEXCompatibility MasomodeEXCompatibility { get; private set; }
         internal bool MasomodeEXLoaded => MasomodeEXCompatibility != null;
 
-        #endregion
+        #endregion Compatibilities
     }
 
-    enum MsgType : byte
+    internal enum MsgType : byte
     {
         ProjectileHostility,
         SyncAI

--- a/Fargowiltas.cs
+++ b/Fargowiltas.cs
@@ -21,11 +21,9 @@ using FargowiltasSouls.NPCs.EternityMode;
 using FargowiltasSouls.Sky;
 using Fargowiltas.Items.Summons.Deviantt;
 using Fargowiltas.Items.Misc;
-using Fargowiltas.Items.Tiles;
 using Fargowiltas.Items.Explosives;
 using Microsoft.Xna.Framework.Graphics;
 using FargowiltasSouls.Items.Dyes;
-using FargowiltasSouls.Items.Misc;
 
 namespace FargowiltasSouls
 {
@@ -46,6 +44,25 @@ namespace FargowiltasSouls
         public UserInterface CustomResources;
 
         internal static readonly Dictionary<int, int> ModProjDict = new Dictionary<int, int>();
+
+        #region Compatibilities
+
+        public CalamityCompatibility CalamityCompatibility { get; private set; }
+        public bool CalamityLoaded => CalamityCompatibility != null;
+
+        public ThoriumCompatibility ThoriumCompatibility { get; private set; }
+        public bool ThoriumLoaded => ThoriumCompatibility != null;
+
+        public SoACompatibility SoACompatibility { get; private set; }
+        public bool SoALoaded => SoACompatibility != null;
+
+        public MasomodeEXCompatibility MasomodeEXCompatibility { get; private set; }
+        public bool MasomodeEXLoaded => MasomodeEXCompatibility != null;
+
+        public BossChecklistCompatibility BossChecklistCompatibility { get; private set; }
+        public bool BossChecklistLoaded => BossChecklistCompatibility != null;
+
+        #endregion Compatibilities
 
         public Fargowiltas()
         {
@@ -529,8 +546,10 @@ namespace FargowiltasSouls
                 CalamityCompatibility = new CalamityCompatibility(this).TryLoad() as CalamityCompatibility;
                 ThoriumCompatibility = new ThoriumCompatibility(this).TryLoad() as ThoriumCompatibility;
                 SoACompatibility = new SoACompatibility(this).TryLoad() as SoACompatibility;
-
                 MasomodeEXCompatibility = new MasomodeEXCompatibility(this).TryLoad() as MasomodeEXCompatibility;
+                BossChecklistCompatibility = (BossChecklistCompatibility)new BossChecklistCompatibility(this).TryLoad();
+
+                BossChecklistCompatibility.Initialize();
 
                 DebuffIDs = new List<int> { 20, 22, 23, 24, 36, 39, 44, 46, 47, 67, 68, 69, 70, 80,
                     88, 94, 103, 137, 144, 145, 148, 149, 156, 160, 163, 164, 195, 196, 197, 199 };
@@ -592,321 +611,6 @@ namespace FargowiltasSouls
                     bossHealthBar.Call("RegisterHealthBarMini", ModContent.NPCType<NatureChampion>());
                 }
 
-                Mod bossChecklist = ModLoader.GetMod("BossChecklist");
-                Mod musicMod = ModLoader.GetMod("FargowiltasMusic");
-                if (bossChecklist != null)
-                {
-                    // Add Souls boss information
-                    bossChecklist.Call(
-                        "AddBoss",
-                        5.01f,
-                        ModContent.NPCType<DeviBoss>(),
-                        this,
-                        "Deviantt",
-                        (Func<bool>)(() => FargoSoulsWorld.downedDevi),
-                        ModContent.ItemType<Items.Summons.DevisCurse>(),
-                        musicMod != null ? new List<int> { ModContent.ItemType<Items.Tiles.DeviTrophy>(), musicMod.ItemType("DeviMusicBox") }
-                        : new List<int> { ModContent.ItemType<Items.Tiles.DeviTrophy>() },
-                        new List<int> { ModContent.ItemType<Items.Misc.DeviatingEnergy>() },
-                        "Spawn by using [i:" + ModContent.ItemType<Items.Summons.DevisCurse>() + "].",
-                        "Deviantt is satisfied with its show of love.",
-                        "FargowiltasSouls/NPCs/DeviBoss/DeviBoss_Still",
-                        "FargowiltasSouls/NPCs/DeviBoss/DeviBoss_Head_Boss"
-                    );
-                    bossChecklist.Call(
-                        "AddMiniBoss",
-                        14.0001f,
-                        ModContent.NPCType<TimberChampion>(),
-                        this,
-                        "Champion of Timber",
-                        (Func<bool>)(() => FargoSoulsWorld.downedChampions[0]),
-                        ModContent.ItemType<Items.Summons.SigilOfChampions>(),
-                        new List<int> { },
-                        new List<int> {
-                            ModContent.ItemType<WoodEnchant>(),
-                            ModContent.ItemType<BorealWoodEnchant>(),
-                            ModContent.ItemType<RichMahoganyEnchant>(),
-                            ModContent.ItemType<EbonwoodEnchant>(),
-                            ModContent.ItemType<ShadewoodEnchant>(),
-                            ModContent.ItemType<PalmWoodEnchant>(),
-                            ModContent.ItemType<PearlwoodEnchant>()
-                        },
-                        "Spawn by using [i:" + ModContent.ItemType<Items.Summons.SigilOfChampions>() + "] on the surface at day.",
-                        "Champion of Timber returns to its squirrel clan...",
-                        "FargowiltasSouls/NPCs/Champions/TimberChampion_Still",
-                        "FargowiltasSouls/NPCs/Champions/TimberChampion_Head_Boss"
-                    );
-                    bossChecklist.Call(
-                        "AddMiniBoss",
-                        14.001f,
-                        ModContent.NPCType<TerraChampion>(),
-                        this,
-                        "Champion of Terra",
-                        (Func<bool>)(() => FargoSoulsWorld.downedChampions[1]),
-                        ModContent.ItemType<Items.Summons.SigilOfChampions>(),
-                        new List<int> { },
-                        new List<int> {
-                            ModContent.ItemType<CopperEnchant>(),
-                            ModContent.ItemType<TinEnchant>(),
-                            ModContent.ItemType<IronEnchant>(),
-                            ModContent.ItemType<LeadEnchant>(),
-                            ModContent.ItemType<TungstenEnchant>(),
-                            ModContent.ItemType<ObsidianEnchant>()
-                        },
-                        "Spawn by using [i:" + ModContent.ItemType<Items.Summons.SigilOfChampions>() + "] underground.",
-                        "Champion of Terra vanishes into the caverns...",
-                        "FargowiltasSouls/NPCs/Champions/TerraChampion_Still",
-                        "FargowiltasSouls/NPCs/Champions/TerraChampion_Head_Boss"
-                    );
-                    bossChecklist.Call(
-                        "AddMiniBoss",
-                        14.002f,
-                        ModContent.NPCType<EarthChampion>(),
-                        this,
-                        "Champion of Earth",
-                        (Func<bool>)(() => FargoSoulsWorld.downedChampions[2]),
-                        ModContent.ItemType<Items.Summons.SigilOfChampions>(),
-                        new List<int> { },
-                        new List<int> {
-                            ModContent.ItemType<CobaltEnchant>(),
-                            ModContent.ItemType<PalladiumEnchant>(),
-                            ModContent.ItemType<MythrilEnchant>(),
-                            ModContent.ItemType<OrichalcumEnchant>(),
-                            ModContent.ItemType<AdamantiteEnchant>(),
-                            ModContent.ItemType<TitaniumEnchant>()
-                        },
-                        "Spawn by using [i:" + ModContent.ItemType<Items.Summons.SigilOfChampions>() + "] in the underworld.",
-                        "Champion of Earth disappears beneath the magma...",
-                        "FargowiltasSouls/NPCs/Champions/EarthChampion_Still",
-                        "FargowiltasSouls/NPCs/Champions/EarthChampion_Head_Boss"
-                    );
-                    bossChecklist.Call(
-                        "AddMiniBoss",
-                        14.003f,
-                        ModContent.NPCType<NatureChampion>(),
-                        this,
-                        "Champion of Nature",
-                        (Func<bool>)(() => FargoSoulsWorld.downedChampions[3]),
-                        ModContent.ItemType<Items.Summons.SigilOfChampions>(),
-                        new List<int> { },
-                        new List<int> {
-                            ModContent.ItemType<CrimsonEnchant>(),
-                            ModContent.ItemType<MoltenEnchant>(),
-                            ModContent.ItemType<RainEnchant>(),
-                            ModContent.ItemType<FrostEnchant>(),
-                            ModContent.ItemType<ChlorophyteEnchant>(),
-                            ModContent.ItemType<ShroomiteEnchant>()
-                        },
-                        "Spawn by using [i:" + ModContent.ItemType<Items.Summons.SigilOfChampions>() + "] in underground snow.",
-                        "Champion of Nature returns to its slumber...",
-                        "FargowiltasSouls/NPCs/Champions/NatureChampion_Still",
-                        "FargowiltasSouls/NPCs/Champions/NatureChampionHead_Head_Boss"
-                    );
-                    bossChecklist.Call(
-                        "AddMiniBoss",
-                        14.004f,
-                        ModContent.NPCType<LifeChampion>(),
-                        this,
-                        "Champion of Life",
-                        (Func<bool>)(() => FargoSoulsWorld.downedChampions[4]),
-                        ModContent.ItemType<Items.Summons.SigilOfChampions>(),
-                        new List<int> { },
-                        new List<int> {
-                            ModContent.ItemType<PumpkinEnchant>(),
-                            ModContent.ItemType<BeeEnchant>(),
-                            ModContent.ItemType<SpiderEnchant>(),
-                            ModContent.ItemType<TurtleEnchant>(),
-                            ModContent.ItemType<BeetleEnchant>()
-                        },
-                        "Spawn by using [i:" + ModContent.ItemType<Items.Summons.SigilOfChampions>() + "] in the Hallow at day.",
-                        "Champion of Life fades away...",
-                        "FargowiltasSouls/NPCs/Champions/LifeChampion_Still",
-                        "FargowiltasSouls/NPCs/Champions/LifeChampion_Head_Boss"
-                    );
-                    bossChecklist.Call(
-                        "AddMiniBoss",
-                        14.005f,
-                        ModContent.NPCType<ShadowChampion>(),
-                        this,
-                        "Champion of Shadow",
-                        (Func<bool>)(() => FargoSoulsWorld.downedChampions[5]),
-                        ModContent.ItemType<Items.Summons.SigilOfChampions>(),
-                        new List<int> { },
-                        new List<int> {
-                            ModContent.ItemType<AncientShadowEnchant>(),
-                            ModContent.ItemType<NecroEnchant>(),
-                            ModContent.ItemType<SpookyEnchant>(),
-                            ModContent.ItemType<ShinobiEnchant>(),
-                            ModContent.ItemType<DarkArtistEnchant>()
-                        },
-                        "Spawn by using [i:" + ModContent.ItemType<Items.Summons.SigilOfChampions>() + "] in the Corruption or Crimson at night.",
-                        "Champion of Shadow fades away...",
-                        "FargowiltasSouls/NPCs/Champions/ShadowChampion_Still",
-                        "FargowiltasSouls/NPCs/Champions/ShadowChampion_Head_Boss"
-                    );
-                    bossChecklist.Call(
-                        "AddMiniBoss",
-                        14.006f,
-                        ModContent.NPCType<SpiritChampion>(),
-                        this,
-                        "Champion of Spirit",
-                        (Func<bool>)(() => FargoSoulsWorld.downedChampions[6]),
-                        ModContent.ItemType<Items.Summons.SigilOfChampions>(),
-                        new List<int> { },
-                        new List<int> {
-                            ModContent.ItemType<FossilEnchant>(),
-                            ModContent.ItemType<ForbiddenEnchant>(),
-                            ModContent.ItemType<HallowEnchant>(),
-                            ModContent.ItemType<TikiEnchant>(),
-                            ModContent.ItemType<SpectreEnchant>()
-                        },
-                        "Spawn by using [i:" + ModContent.ItemType<Items.Summons.SigilOfChampions>() + "] in underground desert.",
-                        "Champion of Spirit vanishes into the desert...",
-                        "FargowiltasSouls/NPCs/Champions/SpiritChampion_Still",
-                        "FargowiltasSouls/NPCs/Champions/SpiritChampion_Head_Boss"
-                    );
-                    bossChecklist.Call(
-                        "AddMiniBoss",
-                        14.007f,
-                        ModContent.NPCType<WillChampion>(),
-                        this,
-                        "Champion of Will",
-                        (Func<bool>)(() => FargoSoulsWorld.downedChampions[7]),
-                        ModContent.ItemType<Items.Summons.SigilOfChampions>(),
-                        new List<int> { },
-                        new List<int> {
-                            ModContent.ItemType<GoldEnchant>(),
-                            ModContent.ItemType<PlatinumEnchant>(),
-                            ModContent.ItemType<GladiatorEnchant>(),
-                            ModContent.ItemType<RedRidingEnchant>(),
-                            ModContent.ItemType<ValhallaKnightEnchant>()
-                        },
-                        "Spawn by using [i:" + ModContent.ItemType<Items.Summons.SigilOfChampions>() + "] at the ocean.",
-                        "Champion of Will returns to the depths...",
-                        "FargowiltasSouls/NPCs/Champions/WillChampion_Still",
-                        "FargowiltasSouls/NPCs/Champions/WillChampion_Head_Boss"
-                    );
-                    bossChecklist.Call(
-                        "AddBoss",
-                        14.008f,
-                        ModContent.NPCType<CosmosChampion>(),
-                        this,
-                        "Eridanus, Champion of Cosmos",
-                        (Func<bool>)(() => FargoSoulsWorld.downedChampions[8]),
-                        ModContent.ItemType<Items.Summons.SigilOfChampions>(),
-                        new List<int> { },
-                        new List<int> {
-                            ModContent.ItemType<SolarEnchant>(),
-                            ModContent.ItemType<NebulaEnchant>(),
-                            ModContent.ItemType<VortexEnchant>(),
-                            ModContent.ItemType<StardustEnchant>(),
-                            ModContent.ItemType<MeteorEnchant>()
-                        },
-                        "Spawn by using [i:" + ModContent.ItemType<Items.Summons.SigilOfChampions>() + "] in space.",
-                        "Eridanus, Champion of Cosmos returns to the stars...",
-                        "FargowiltasSouls/NPCs/Champions/CosmosChampion_Still",
-                        "FargowiltasSouls/NPCs/Champions/CosmosChampion_Head_Boss"
-                    );
-                    bossChecklist.Call(
-                        "AddBoss",
-                        14.01f,
-                        ModContent.NPCType<AbomBoss>(),
-                        this,
-                        "Abominationn",
-                        (Func<bool>)(() => FargoSoulsWorld.downedAbom),
-                        ModContent.ItemType<Items.Summons.AbomsCurse>(),
-                        musicMod != null ? new List<int> { ModContent.ItemType<Items.Tiles.AbomTrophy>(), musicMod.ItemType("AbomMusicBox") }
-                        : new List<int> { ModContent.ItemType<Items.Tiles.AbomTrophy>() },
-                        new List<int> { ModContent.ItemType<Items.Misc.MutantScale>() },
-                        "Spawn by using [i:" + ModContent.ItemType<Items.Summons.AbomsCurse>() + "].",
-                        "Abominationn has destroyed everyone.",
-                        "FargowiltasSouls/NPCs/AbomBoss/AbomBoss_Still",
-                        "FargowiltasSouls/NPCs/AbomBoss/AbomBoss_Head_Boss"
-                    );
-                    /*bossChecklist.Call(                  this code crashes the game when you scroll down to the boss in the checklist
-                        "AddBoss",                         probably has something to do with the NPC line...
-                        14.6f,
-                        NPCID.DukeFishron,                 ...because fish.
-                        this,
-                        "Duke Fishron EX",
-                        (Func<bool>)(() => FargoSoulsWorld.downedFishronEX),
-                        ModContent.ItemType<Items.Misc.TruffleWormEX>(),
-                        ModContent.ItemType<Items.Misc.AbomMusicBox>(),
-                        ModContent.ItemType<Items.Misc.MutatingEnergy>(),
-                        "Fish using the Truffle Worm EX.",
-                        "The Duke returns to the depths victoriously...",
-                        "FargowiltasSouls/NPCs/Vanilla/NPC_370",
-                        "FargowiltasSouls/NPCs/Vanilla/NPC_Head_Boss_4"
-                    );*/
-                    //bossChecklist.Call("AddBossWithInfo", "Duke Fishron EX", 14.02f, (Func<bool>)(() => FargoSoulsWorld.downedFishronEX), "Fish using a [i:" + ItemType("TruffleWormEX") + "]");
-                    if (ModLoader.GetMod("CalamityMod") != null)
-                    {
-                        bossChecklist.Call(
-                            "AddBoss",
-                            20.0f,
-                            ModContent.NPCType<MutantBoss>(),
-                            this,
-                            "Mutant",
-                            (Func<bool>)(() => FargoSoulsWorld.downedMutant),
-                            ModContent.ItemType<Items.Summons.AbominationnVoodooDoll>(),
-                            musicMod != null ? new List<int> { ModContent.ItemType<Items.Tiles.MutantTrophy>(), musicMod.ItemType("MutantMusicBox") }
-                            : new List<int> { ModContent.ItemType<Items.Tiles.MutantTrophy>() },
-                            ModContent.ItemType<Items.Misc.Sadism>(),
-                            "Throw [i:" + ModContent.ItemType<Items.Summons.AbominationnVoodooDoll>() + "] into a pool of lava while Abominationn is alive, in Mutant's presence.",
-                            "Mutant has eviscerated everyone under its hands.",
-                            "FargowiltasSouls/NPCs/MutantBoss/MutantBoss_Still",
-                            "FargowiltasSouls/NPCs/MutantBoss/MutantBoss_Head_Boss"
-                        );
-                    }
-                    else
-                    {
-                        bossChecklist.Call(
-                            "AddBoss",
-                            14.03f,
-                            ModContent.NPCType<MutantBoss>(),
-                            this,
-                            "Mutant",
-                            (Func<bool>)(() => FargoSoulsWorld.downedMutant),
-                            ModContent.ItemType<Items.Summons.AbominationnVoodooDoll>(),
-                            musicMod != null ? new List<int> { ModContent.ItemType<Items.Tiles.MutantTrophy>(), musicMod.ItemType("MutantMusicBox") }
-                            : new List<int> { ModContent.ItemType<Items.Tiles.MutantTrophy>() },
-                            ModContent.ItemType<Items.Misc.Sadism>(),
-                            "Throw [i:" + ModContent.ItemType<Items.Summons.AbominationnVoodooDoll>() + "] into a pool of lava while Abominationn is alive, in Mutant's presence.",
-                            "Mutant has eviscerated everyone under its hands.",
-                            "FargowiltasSouls/NPCs/MutantBoss/MutantBoss_Still",
-                            "FargowiltasSouls/NPCs/MutantBoss/MutantBoss_Head_Boss"
-                        );
-                    }
-
-                    // Add vanilla boss information
-                    bossChecklist.Call("AddToBossLoot", "Terraria", "PirateShip", new List<int> { ModContent.ItemType<SecurityWallet>() }); // Coin gun & lucky coin are already dropped
-                    bossChecklist.Call("AddToBossLoot", "Terraria", "MourningWood", new List<int> { ItemID.BloodyMachete });
-                    bossChecklist.Call("AddToBossLoot", "Terraria", "Pumpking", new List<int> { ItemID.BladedGlove, ModContent.ItemType<PumpkingsCape>() });
-                    bossChecklist.Call("AddToBossLoot", "Terraria", "IceQueen", new List<int> { ModContent.ItemType<IceQueensCrown>() });
-                    bossChecklist.Call("AddToBossLoot", "Terraria", "MartianSaucerCore", new List<int> { ModContent.ItemType<SaucerControlConsole>() });
-
-                    // Should we shoe presents? They contribute virtually nothing
-                    bossChecklist.Call("AddToBossLoot", "Terraria", "Everscream", new List<int> { ItemID.Present }); // TODO: Extension methods to reduce boilerplate
-                    bossChecklist.Call("AddToBossLoot", "Terraria", "SantaNK1", new List<int> { ItemID.Present });
-
-                    // Only include important drops, crates and stuff hardly matter
-                    bossChecklist.Call("AddToBossLoot", "Terraria", "KingSlime", new List<int> { ModContent.ItemType<SlimyShield>() });
-                    bossChecklist.Call("AddToBossLoot", "Terraria", "EyeofCthulhu", new List<int> { ModContent.ItemType<AgitatingLens>() });
-                    bossChecklist.Call("AddToBossLoot", "Terraria", "EaterofWorldsHead", new List<int> { ModContent.ItemType<CorruptHeart>() });
-                    bossChecklist.Call("AddToBossLoot", "Terraria", "BrainofCthulhu", new List<int> { ModContent.ItemType<GuttedHeart>() });
-                    bossChecklist.Call("AddToBossLoot", "Terraria", "SkeletronHead", new List<int> { ModContent.ItemType<NecromanticBrew>() });
-                    bossChecklist.Call("AddToBossLoot", "Terraria", "QueenBee", new List<int> { ModContent.ItemType<QueenStinger>() });
-                    bossChecklist.Call("AddToBossLoot", "Terraria", "WallofFlesh", new List<int> { ModContent.ItemType<PungentEyeball>(), ModContent.ItemType<MutantsDiscountCard>() });
-                    bossChecklist.Call("AddToBossLoot", "Terraria", "TheTwins", new List<int> { ModContent.ItemType<FusedLens>() });
-                    bossChecklist.Call("AddToBossLoot", "Terraria", "TheDestroyer", new List<int> { ModContent.ItemType<GroundStick>() });
-                    bossChecklist.Call("AddToBossLoot", "Terraria", "SkeletronPrime", new List<int> { ModContent.ItemType<ReinforcedPlating>() });
-                    bossChecklist.Call("AddToBossLoot", "Terraria", "Plantera", new List<int> { ModContent.ItemType<MagicalBulb>() });
-                    bossChecklist.Call("AddToBossLoot", "Terraria", "Golem", new List<int> { ModContent.ItemType<LihzahrdTreasureBox>() });
-                    bossChecklist.Call("AddToBossLoot", "Terraria", "DD2Betsy", new List<int> { ModContent.ItemType<BetsysHeart>() });
-                    bossChecklist.Call("AddToBossLoot", "Terraria", "DukeFishron", new List<int> { ModContent.ItemType<MutantAntibodies>(), ModContent.ItemType<MutantsPact>() });
-                    bossChecklist.Call("AddToBossLoot", "Terraria", "CultistBoss", new List<int> { ModContent.ItemType<CelestialRune>(), ModContent.ItemType<CelestialSeal>() });
-                    bossChecklist.Call("AddToBossLoot", "Terraria", "MoonLord", new List<int> { ModContent.ItemType<GalacticGlobe>() });
-                }
                 //mutant shop
                 Mod fargos = ModLoader.GetMod("Fargowiltas");
                 fargos.Call("AddSummon", 5.01f, "FargowiltasSouls", "DevisCurse", (Func<bool>)(() => FargoSoulsWorld.downedDevi), Item.buyPrice(0, 17, 50));
@@ -1360,22 +1064,6 @@ namespace FargowiltasSouls
         {
             return NormalSpawn(spawnInfo) && NoBiome(spawnInfo) && NoZone(spawnInfo);
         }
-
-        #region Compatibilities
-
-        internal CalamityCompatibility CalamityCompatibility { get; private set; }
-        internal bool CalamityLoaded => CalamityCompatibility != null;
-
-        internal ThoriumCompatibility ThoriumCompatibility { get; private set; }
-        internal bool ThoriumLoaded => ThoriumCompatibility != null;
-
-        internal SoACompatibility SoACompatibility { get; private set; }
-        internal bool SoALoaded => SoACompatibility != null;
-
-        internal MasomodeEXCompatibility MasomodeEXCompatibility { get; private set; }
-        internal bool MasomodeEXLoaded => MasomodeEXCompatibility != null;
-
-        #endregion Compatibilities
     }
 
     internal enum MsgType : byte

--- a/ModCompatibilities/BossChecklistCompatibility.cs
+++ b/ModCompatibilities/BossChecklistCompatibility.cs
@@ -1,0 +1,326 @@
+﻿using FargowiltasSouls.Items.Accessories.Enchantments;
+using FargowiltasSouls.Items.Accessories.Masomode;
+using FargowiltasSouls.Items.Misc;
+using FargowiltasSouls.Items.Summons;
+using FargowiltasSouls.Items.Tiles;
+using FargowiltasSouls.Items.Weapons.BossDrops;
+using FargowiltasSouls.NPCs.AbomBoss;
+using FargowiltasSouls.NPCs.Champions;
+using FargowiltasSouls.NPCs.DeviBoss;
+using FargowiltasSouls.NPCs.MutantBoss;
+using FargowiltasSouls.Patreon.Catsounds;
+using FargowiltasSouls.Patreon.Daawnz;
+using System;
+using System.Collections.Generic;
+using Terraria.ID;
+using Terraria.ModLoader;
+
+namespace FargowiltasSouls.ModCompatibilities
+{
+    public class BossChecklistCompatibility : ModCompatibility
+    {
+        public BossChecklistCompatibility(Mod callerMod) : base(callerMod, "BossChecklist")
+        {
+        }
+
+        public void Initialize()
+        {
+            if (ModInstance != null)
+            {
+                InitializeBosses();
+                InitializeMinibosses();
+                InitializeBossLoot();
+            }
+        }
+
+        private void InitializeBosses()
+        {
+            Mod musicMod = ModLoader.GetMod("FargowiltasMusic");
+
+            List<int> deviCollection = new List<int>
+            {
+                ModContent.ItemType<DeviTrophy>()
+            };
+
+            List<int> abomCollection = new List<int>
+            {
+                ModContent.ItemType<AbomTrophy>()
+            };
+
+            List<int> mutantCollection = new List<int>
+            {
+                ModContent.ItemType<MutantTrophy>()
+            };
+
+            if (musicMod != null)
+            {
+                deviCollection.Add(musicMod.ItemType("DeviMusicBox"));
+                abomCollection.Add(musicMod.ItemType("AbomMusicBox"));
+                mutantCollection.Add(musicMod.ItemType("MutantMusicBox"));
+            }
+
+            AddBoss(ModContent.NPCType<DeviBoss>(),
+                5.01f,
+                "Deviantt",
+                () => FargoSoulsWorld.downedDevi,
+                ModContent.ItemType<DevisCurse>(),
+                deviCollection,
+                ModContent.ItemType<DeviatingEnergy>(),
+                $"Spawn by using [i:{ModContent.ItemType<DevisCurse>()}].",
+                "Deviantt is satisfied with its show of love.",
+                "FargowiltasSouls/NPCs/DeviBoss/DeviBoss_Still",
+                "FargowiltasSouls/NPCs/DeviBoss/DeviBoss_Head_Boss");
+
+            AddBoss(ModContent.NPCType<AbomBoss>(),
+                14.01f,
+                "Abominationn",
+                () => FargoSoulsWorld.downedAbom,
+                ModContent.ItemType<AbomsCurse>(),
+                abomCollection,
+                ModContent.ItemType<MutantScale>(),
+                $"Spawn by using [i:{ModContent.ItemType<AbomsCurse>()}].",
+                "Abominationn has destroyed everyone.",
+                "FargowiltasSouls/NPCs/DeviBoss/AbomBoss_Still",
+                "FargowiltasSouls/NPCs/DeviBoss/AbomBoss_Head_Boss");
+
+            AddBoss(ModContent.NPCType<MutantBoss>(),
+                ModLoader.GetMod("CalamityMod") != null ? 20f : 14.03f,
+                "Mutant",
+                () => FargoSoulsWorld.downedMutant,
+                ModContent.ItemType<AbominationnVoodooDoll>(),
+                mutantCollection,
+                ModContent.ItemType<Sadism>(),
+                $"Throw [i:{ModContent.ItemType<AbominationnVoodooDoll>()}] into a pool of lava while Abominationn is alivem in Mutant's presence.",
+                "Mutant has eviscerated everyone under its hands.",
+                "FargowiltasSouls/NPCs/DeviBoss/MutantBoss_Still",
+                "FargowiltasSouls/NPCs/DeviBoss/MutantBoss_Head_Boss");
+        }
+
+        private void InitializeMinibosses()
+        {
+            AddMiniboss(ModContent.NPCType<TimberChampion>(),
+                14.0001f,
+                "Champion of Timber",
+                () => FargoSoulsWorld.downedChampions[0],
+                ModContent.ItemType<SigilOfChampions>(),
+                new List<int>
+                {
+                    ModContent.ItemType<WoodEnchant>(),
+                    ModContent.ItemType<BorealWoodEnchant>(),
+                    ModContent.ItemType<RichMahoganyEnchant>(),
+                    ModContent.ItemType<EbonwoodEnchant>(),
+                    ModContent.ItemType<ShadewoodEnchant>(),
+                    ModContent.ItemType<PalmWoodEnchant>(),
+                    ModContent.ItemType<PearlwoodEnchant>()
+                },
+                $"Spawn by using [i:{ModContent.ItemType<SigilOfChampions>()}] on the surface during the day.",
+                "Champion of Timber returns to its squirrel clan...",
+                "FargowiltasSouls/NPCs/Champions/TimberChampion_Still",
+                "FargowiltasSouls/NPCs/Champions/TimberChampion_Head_Boss");
+
+            AddMiniboss(ModContent.NPCType<TerraChampion>(),
+                14.001f,
+                "Champion of Terra",
+                () => FargoSoulsWorld.downedChampions[1],
+                ModContent.ItemType<SigilOfChampions>(),
+                new List<int>
+                {
+                    ModContent.ItemType<CopperEnchant>(),
+                    ModContent.ItemType<TinEnchant>(),
+                    ModContent.ItemType<IronEnchant>(),
+                    ModContent.ItemType<LeadEnchant>(),
+                    ModContent.ItemType<TungstenEnchant>(),
+                    ModContent.ItemType<ObsidianEnchant>()
+                },
+                $"Spawn by using [i:{ModContent.ItemType<SigilOfChampions>()}] underground.",
+                "Champion of Terra vanishes into the caverns...",
+                "FargowiltasSouls/NPCs/Champions/TerraChampion_Still",
+                "FargowiltasSouls/NPCs/Champions/TerraChampion_Head_Boss");
+
+            AddMiniboss(ModContent.NPCType<EarthChampion>(),
+                14.002f,
+                "Champion of Earth",
+                () => FargoSoulsWorld.downedChampions[2],
+                ModContent.ItemType<SigilOfChampions>(),
+                new List<int>
+                {
+                    ModContent.ItemType<CobaltEnchant>(),
+                    ModContent.ItemType<PalladiumEnchant>(),
+                    ModContent.ItemType<MythrilEnchant>(),
+                    ModContent.ItemType<OrichalcumEnchant>(),
+                    ModContent.ItemType<AdamantiteEnchant>(),
+                    ModContent.ItemType<TitaniumEnchant>()
+                },
+                $"Spawn by using [i:{ModContent.ItemType<SigilOfChampions>()}] in the underworld.",
+                "Champion of Earth disappears beneath the magma...",
+                "FargowiltasSouls/NPCs/Champions/EarthChampion_Still",
+                "FargowiltasSouls/NPCs/Champions/EarthChampion_Head_Boss");
+
+            AddMiniboss(ModContent.NPCType<NatureChampion>(),
+                14.003f,
+                "Champion of Nature",
+                () => FargoSoulsWorld.downedChampions[3],
+                ModContent.ItemType<SigilOfChampions>(),
+                new List<int>
+                {
+                    ModContent.ItemType<CrimsonEnchant>(),
+                    ModContent.ItemType<MoltenEnchant>(),
+                    ModContent.ItemType<RainEnchant>(),
+                    ModContent.ItemType<FrostEnchant>(),
+                    ModContent.ItemType<ChlorophyteEnchant>(),
+                    ModContent.ItemType<ShroomiteEnchant>()
+                },
+                $"Spawn by using [i:{ModContent.ItemType<SigilOfChampions>()}] in underground snow.",
+                "Champion of Nature returns to its slumber",
+                "FargowiltasSouls/NPCs/Champions/NatureChampion_Still",
+                "FargowiltasSouls/NPCs/Champions/NatureChampionHead_Head_Boss");
+
+            AddMiniboss(ModContent.NPCType<LifeChampion>(),
+                14.004f,
+                "Champion of Life",
+                () => FargoSoulsWorld.downedChampions[4],
+                ModContent.ItemType<SigilOfChampions>(),
+                new List<int>
+                {
+                    ModContent.ItemType<PumpkinEnchant>(),
+                    ModContent.ItemType<BeeEnchant>(),
+                    ModContent.ItemType<SpiderEnchant>(),
+                    ModContent.ItemType<TurtleEnchant>(),
+                    ModContent.ItemType<BeetleEnchant>()
+                },
+                $"Spawn by using [i:{ModContent.ItemType<SigilOfChampions>()}] in the Hallow at day.",
+                "Champion of Life fades away...",
+                "FargowiltasSouls/NPCs/Champions/LifeChampion_Still",
+                "FargowiltasSouls/NPCs/Champions/LifeChampion_Head_Boss");
+
+            AddMiniboss(ModContent.NPCType<ShadowChampion>(),
+                14.005f,
+                "Champion of Shadow",
+                () => FargoSoulsWorld.downedChampions[5],
+                ModContent.ItemType<SigilOfChampions>(),
+                new List<int>
+                {
+                    ModContent.ItemType<AncientShadowEnchant>(),
+                    ModContent.ItemType<NecroEnchant>(),
+                    ModContent.ItemType<SpookyEnchant>(),
+                    ModContent.ItemType<ShinobiEnchant>(),
+                    ModContent.ItemType<DarkArtistEnchant>()
+                },
+                $"Spawn by using [i:{ModContent.ItemType<SigilOfChampions>()}] in the Corruption or Crimson at night.",
+                "Champion of Shadow fades away...",
+                "FargowiltasSouls/NPCs/Champions/ShadowChampion_Still",
+                "FargowiltasSouls/NPCs/Champions/ShadowChampion_Head_Boss");
+
+            AddMiniboss(ModContent.NPCType<SpiritChampion>(),
+                14.006f,
+                "Champion of Spirit",
+                () => FargoSoulsWorld.downedChampions[6],
+                ModContent.ItemType<SigilOfChampions>(),
+                new List<int>
+                {
+                    ModContent.ItemType<FossilEnchant>(),
+                    ModContent.ItemType<ForbiddenEnchant>(),
+                    ModContent.ItemType<HallowEnchant>(),
+                    ModContent.ItemType<TikiEnchant>(),
+                    ModContent.ItemType<SpectreEnchant>()
+                },
+                $"Spawn by using [i:{ModContent.ItemType<SigilOfChampions>()}] in the underground desert.",
+                "Champion of Spirit vanishes into the desert...",
+                "FargowiltasSouls/NPCs/Champions/SpiritChampion_Still",
+                "FargowiltasSouls/NPCs/Champions/SpiritChampion_Head_Boss");
+
+            AddMiniboss(ModContent.NPCType<WillChampion>(),
+                14.007f,
+                "Champion of Will",
+                () => FargoSoulsWorld.downedChampions[7],
+                ModContent.ItemType<SigilOfChampions>(),
+                new List<int>
+                {
+                    ModContent.ItemType<GoldEnchant>(),
+                    ModContent.ItemType<PlatinumEnchant>(),
+                    ModContent.ItemType<GladiatorEnchant>(),
+                    ModContent.ItemType<RedRidingEnchant>(),
+                    ModContent.ItemType<ValhallaKnightEnchant>()
+                },
+                $"Spawn by using [i:{ModContent.ItemType<SigilOfChampions>()}] at the ocean.",
+                "Champion of Will returns to the depths...",
+                "FargowiltasSouls/NPCs/Champions/WillChampion_Still",
+                "FargowiltasSouls/NPCs/Champions/WillChampion_Head_Boss");
+
+            AddMiniboss(ModContent.NPCType<CosmosChampion>(),
+                14.008f,
+                "Eridanus, Champion of Cosmos",
+                () => FargoSoulsWorld.downedChampions[8],
+                ModContent.ItemType<SigilOfChampions>(),
+                new List<int>
+                {
+                    ModContent.ItemType<SolarEnchant>(),
+                    ModContent.ItemType<NebulaEnchant>(),
+                    ModContent.ItemType<VortexEnchant>(),
+                    ModContent.ItemType<StardustEnchant>(),
+                    ModContent.ItemType<MeteorEnchant>()
+                },
+                $"Spawn by using [i:{ModContent.ItemType<SigilOfChampions>()}] in space.",
+                "Eridanus, Champion of Cosmos returns to the stars...",
+                "FargowiltasSouls/NPCs/Champions/CosmosChampion_Still",
+                "FargowiltasSouls/NPCs/Champions/CosmosChampion_Head_Boss");
+        }
+
+        private void InitializeBossLoot()
+        {
+            // Mini-bosses
+            AddToBossLoot("PirateShip", ModContent.ItemType<SecurityWallet>()); // Coin gun & lucky coin are already dropped
+            AddToBossLoot("MourningWood", ItemID.BloodyMachete);
+            AddToBossLoot("Pumpking", ItemID.BladedGlove, ModContent.ItemType<PumpkingsCape>());
+            AddToBossLoot("IceQueen", ModContent.ItemType<IceQueensCrown>());
+            AddToBossLoot("MartianSaucerCore", ModContent.ItemType<SaucerControlConsole>());
+
+            AddToBossLoot(new string[2] { "MourningWood", "Pumpking" }, ItemID.GoodieBag);
+            AddToBossLoot(new string[3] { "Everscream", "SantaNK1", "IceQueen" }, ItemID.Present);
+
+            // Bosses
+            AddToBossLoot("KingSlime", ItemID.LifeCrystal, ModContent.ItemType<SlimyShield>(), ModContent.ItemType<MedallionoftheFallenKing>(), ModContent.ItemType<SlimeKingsSlasher>());
+            AddToBossLoot("EyeofCthulhu", ItemID.HerbBag, ModContent.ItemType<AgitatingLens>(), ModContent.ItemType<LeashOfCthulhu>());
+            AddToBossLoot("EaterofWorldsHead", ItemID.CorruptFishingCrate, ModContent.ItemType<CorruptHeart>(), ModContent.ItemType<EaterStaff>());
+            AddToBossLoot("BrainofCthulhu", ItemID.CrimsonFishingCrate, ModContent.ItemType<GuttedHeart>(), ModContent.ItemType<BrainStaff>());
+            AddToBossLoot("SkeletronHead", ItemID.DungeonFishingCrate, ModContent.ItemType<NecromanticBrew>(), ModContent.ItemType<BoneZone>());
+            AddToBossLoot("QueenBee", ModContent.ItemType<QueenStinger>(), ModContent.ItemType<TheSmallSting>());
+            AddToBossLoot("WallofFlesh", ModContent.ItemType<PungentEyeball>(), ItemID.HallowedFishingCrate, ModContent.ItemType<MutantsDiscountCard>(), ModContent.ItemType<FleshHand>()); // Shadow crates as well, but AFAIK those were removed
+            AddToBossLoot("TheTwins", ModContent.ItemType<FusedLens>(), ModContent.ItemType<TwinRangs>());
+            AddToBossLoot("TheDestroyer", ModContent.ItemType<GroundStick>(), ModContent.ItemType<DestroyerGun>());
+            AddToBossLoot("SkeletronPrime", ModContent.ItemType<ReinforcedPlating>(), ModContent.ItemType<RefractorBlaster>());
+            AddToBossLoot("Plantera", ModContent.ItemType<MagicalBulb>(), ItemID.LifeFruit, ItemID.ChlorophyteOre, ModContent.ItemType<Dicer>());
+            AddToBossLoot("Golem", ModContent.ItemType<LihzahrdTreasureBox>(), ModContent.ItemType<ComputationOrb>(), ModContent.ItemType<RockSlide>());
+            AddToBossLoot("DD2Betsy", ModContent.ItemType<BetsysHeart>());
+            AddToBossLoot("DukeFishron", ModContent.ItemType<MutantAntibodies>(), ItemID.Bacon, ModContent.ItemType<MutantsPact>(), ModContent.ItemType<FishStick>(), ItemID.FuzzyCarrot, ItemID.AnglerHat, ItemID.AnglerVest, ItemID.AnglerPants, ItemID.GoldenFishingRod, ItemID.GoldenBugNet, ItemID.FishHook, ItemID.HighTestFishingLine, ItemID.AnglerEarring, ItemID.TackleBox, ItemID.FishermansGuide, ItemID.WeatherRadio, ItemID.Sextant, ItemID.FinWings, ItemID.BottomlessBucket, ItemID.SuperAbsorbantSponge, ItemID.HotlineFishingHook);
+            AddToBossLoot("CultistBoss", ModContent.ItemType<CelestialRune>(), ModContent.ItemType<CelestialSeal>());
+            AddToBossLoot("MoonLord", ModContent.ItemType<GalacticGlobe>());
+
+            AddToBossLoot(new string[2] { "KingSlime", "EyeofCthulhu" }, ItemID.WoodenCrate);
+            AddToBossLoot(new string[2] { "QueenBee", "Plantera" }, ItemID.JungleFishingCrate);
+            AddToBossLoot(new string[3] { "TheTwins", "TheDestroyer", "SkeletronPrime" }, ItemID.IronCrate, ItemID.FallenStar);
+            AddToBossLoot(new string[3] { "Golem", "DD2Betsy", "DukeFishron" }, ItemID.GoldenCrate);
+        }
+
+        public void AddBoss(int npcID, float progression, string npcName, Func<bool> downedBoss, int spawnItemID, List<int> collectionItemIDs, int lootItemID, string spawnInfo, string despawnMessage, string texture, string overrideHeadIconTexutre) => ModInstance.Call("AddBoss", progression, npcID, ModContent.GetInstance<Fargowiltas>(), npcName, downedBoss, spawnItemID, collectionItemIDs, lootItemID, spawnInfo, despawnMessage, texture, overrideHeadIconTexutre);
+
+        public void AddMiniboss(int npcID, float progression, string npcName, Func<bool> downedBoss, int spawnItemID, List<int> lootItemIDs, string spawnInfo, string despawnMessage, string texture, string overrideHeadIconTexutre) => ModInstance.Call("AddMiniBoss", progression, npcID, ModContent.GetInstance<Fargowiltas>(), npcName, downedBoss, spawnItemID, new List<int> { }, lootItemIDs, spawnInfo, despawnMessage, texture, overrideHeadIconTexutre);
+
+        public void AddToBossLoot(string[] npcs, string modName, params int[] itemIDs)
+        {
+            List<int> items = new List<int>();
+
+            foreach (int item in itemIDs)
+                items.Add(item);
+
+            foreach (string npc in npcs)
+                ModInstance.Call("AddToBossList", modName, npc, items);
+        }
+
+        public void AddToBossLoot(string npc, string modName, params int[] itemIDs) => AddToBossLoot(new string[1] { npc }, modName, itemIDs);
+
+        public void AddToBossLoot(string npc, params int[] itemIDs) => AddToBossLoot(new string[1] { npc }, "Terraria", itemIDs);
+
+        public void AddToBossLoot(string[] npcs, params int[] itemIDs) => AddToBossLoot(npcs, "Terraria", itemIDs);
+    }
+}


### PR DESCRIPTION
Fixes #265.

Use Boss Checklist ModCalls to add our modded loot to vanilla boss entries and move Boss Checklist ModCalls to a new class that extends ModCompatibility to fit with other cross-mod stuff as well to reduce clutter.