### PR TITLE
Fix Typo in a BC ModCall

### DIFF
--- a/ModCompatibilities/BossChecklistCompatibility.cs
+++ b/ModCompatibilities/BossChecklistCompatibility.cs
@@ -314,7 +314,7 @@ namespace FargowiltasSouls.ModCompatibilities
                 items.Add(item);
 
             foreach (string npc in npcs)
-                ModInstance.Call("AddToBossList", modName, npc, items);
+                ModInstance.Call("AddToBossLoot", modName, npc, items);
         }
 
         public void AddToBossLoot(string npc, string modName, params int[] itemIDs) => AddToBossLoot(new string[1] { npc }, modName, itemIDs);


### PR DESCRIPTION
Accidentally tried to call "AddToBossList" (which doesn't exist). Fixed (now is "AddToBossLoot").