### PR TITLE
why is dark caster worterbolt projectile visible :trollface:

### DIFF
--- a/Projectiles/Masomode/WaterBoltHostile.cs
+++ b/Projectiles/Masomode/WaterBoltHostile.cs
@@ -23,6 +23,7 @@ namespace FargowiltasSouls.Projectiles.Masomode
             projectile.magic = false;
             projectile.hostile = true;
             projectile.timeLeft = 300;
+            projectile.alpha = 255;
         }
 
         public override void OnHitPlayer(Player target, int damage, bool crit)


### PR DESCRIPTION
:trollface: (test this before merging i cant be bothered to)