### PR TITLE
Support MagicStorageExtra

### DIFF
--- a/Fargowiltas.cs
+++ b/Fargowiltas.cs
@@ -584,6 +584,16 @@ namespace FargowiltasSouls
                 if (Main.netMode != NetmodeID.SinglePlayer)
                     NetMessage.SendData(MessageID.WorldData); //sync world in mp
             }
+            else if (ModLoader.GetMod("MagicStorageExtra") != null && !FargoSoulsWorld.ReceivedTerraStorage)
+            {
+                Item.NewItem(player.Center, ModLoader.GetMod("MagicStorageExtra").ItemType("StorageHeart"));
+                Item.NewItem(player.Center, ModLoader.GetMod("MagicStorageExtra").ItemType("CraftingAccess"));
+                Item.NewItem(player.Center, ModLoader.GetMod("MagicStorageExtra").ItemType("StorageUnit"), 16);
+
+                FargoSoulsWorld.ReceivedTerraStorage = true;
+                if (Main.netMode != NetmodeID.SinglePlayer)
+                    NetMessage.SendData(MessageID.WorldData); //sync world in mp
+            }
         }
 
         //bool sheet


### PR DESCRIPTION
If you have the Magic Storage Extra mod installed instead of the normal Magic Storage mod, you don't get the magic storage gifts. This fixes that.