### PR TITLE
Fixed SotS frigid gemstone toggle

### DIFF
--- a/Items/Accessories/Souls/MasochistSoul.cs
+++ b/Items/Accessories/Souls/MasochistSoul.cs
@@ -196,7 +196,7 @@ Summons the aid of all Eternity Mode bosses to your side
 
             //frigid gemstone
             player.buffImmune[BuffID.Frostburn] = true;
-            if (player.GetToggleValue("MasoClipped"))
+            if (player.GetToggleValue("MasoFrigid"))
             {
                 fargoPlayer.FrigidGemstone = true;
                 if (fargoPlayer.FrigidGemstoneCD > 0)


### PR DESCRIPTION
Soul of the Siblings no longer checks the wrong toggle