### PR TITLE
Tungsten, Squire, Copper, and Palm Wood changes

### DIFF
--- a/Content/Items/Accessories/Enchantments/CopperEnchant.cs
+++ b/Content/Items/Accessories/Enchantments/CopperEnchant.cs
@@ -51,13 +51,13 @@ namespace FargowiltasSouls.Content.Items.Accessories.Enchantments
             {
                 target.AddBuff(BuffID.Electrified, 180);
 
-                int dmg = 35;
+                int dmg = 50;
                 int maxTargets = 1;
                 int cdLength = 300;
 
                 if (modPlayer.ForceEffect(modPlayer.CopperEnchantItem.type))
                 {
-                    dmg = 150;
+                    dmg = 200;
                     maxTargets = 5;
                     cdLength = 150;
                 }

--- a/Content/Items/Accessories/Enchantments/PalmWoodEnchant.cs
+++ b/Content/Items/Accessories/Enchantments/PalmWoodEnchant.cs
@@ -53,11 +53,6 @@ namespace FargowiltasSouls.Content.Items.Accessories.Enchantments
 
                         int maxSpawn = 1;
 
-                        if (modPlayer.ForceEffect(modPlayer.PalmEnchantItem.type))
-                        {
-                            maxSpawn = 2;
-                        }
-
                         if (player.ownedProjectileCounts[ModContent.ProjectileType<PalmTreeSentry>()] > maxSpawn - 1)
                         {
                             for (int i = 0; i < Main.maxProjectiles; i++)

--- a/Content/Items/Accessories/Enchantments/TungstenEnchant.cs
+++ b/Content/Items/Accessories/Enchantments/TungstenEnchant.cs
@@ -50,9 +50,19 @@ Enlarged projectiles and non-projectile swords deal 10% more damage and have an 
 
             modPlayer.TungstenEnchantItem = item;
 
-            if (player.GetToggleValue("Tungsten") && !modPlayer.TerrariaSoul && player.HeldItem.damage > 0 && player.HeldItem.CountsAsClass(DamageClass.Melee) && (!player.HeldItem.noMelee || FargoGlobalItem.TungstenAlwaysAffects.Contains(player.HeldItem.type)) && player.HeldItem.pick == 0 && player.HeldItem.axe == 0 && player.HeldItem.hammer == 0)
+            if (player.GetToggleValue("Tungsten") 
+                && !modPlayer.TerrariaSoul 
+                && modPlayer.ForceEffect(modPlayer.TungstenEnchantItem.type)
+                && player.HeldItem.damage > 0 
+                && player.HeldItem.CountsAsClass(DamageClass.Melee) 
+                && (!player.HeldItem.noMelee || FargoGlobalItem.TungstenAlwaysAffects.Contains(player.HeldItem.type)) 
+                && player.HeldItem.pick == 0 
+                && player.HeldItem.axe == 0 
+                && player.HeldItem.hammer == 0
+                )
             {
-                modPlayer.Player.GetAttackSpeed(DamageClass.Melee) -= 0.5f;
+                float penalty = 0.5f;
+                modPlayer.Player.GetAttackSpeed(DamageClass.Melee) -= penalty;
             }
         }
 
@@ -150,8 +160,9 @@ Enlarged projectiles and non-projectile swords deal 10% more damage and have an 
 
             bool forceBuff = modPlayer.ForceEffect(modPlayer.TungstenEnchantItem.type);
 
-            modifiers.FinalDamage *= forceBuff ? 1.15f : 1.1f;
+            modifiers.FinalDamage *= 1.15f;
 
+            /* fuck you tungsten enchant
             int max = forceBuff ? 2 : 1;
             for (int i = 0; i < max; i++)
             {
@@ -163,7 +174,7 @@ Enlarged projectiles and non-projectile swords deal 10% more damage and have an 
                 {
                     modifiers.SetCrit();
                 }
-            }
+            } */
         }
 
         public override void AddRecipes()
@@ -174,7 +185,7 @@ Enlarged projectiles and non-projectile swords deal 10% more damage and have an 
                 .AddIngredient(ItemID.TungstenGreaves)
                 .AddIngredient(ItemID.TungstenBroadsword)
                 .AddIngredient(ItemID.Ruler)
-                .AddIngredient(ItemID.CandyCaneSword)
+                .AddIngredient(ItemID.Rockfish)
 
                 .AddTile(TileID.DemonAltar)
                 .Register();

--- a/Content/Projectiles/Minions/PalmTreeSentry.cs
+++ b/Content/Projectiles/Minions/PalmTreeSentry.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xna.Framework;
+﻿using FargowiltasSouls.Content.NPCs.EternityModeNPCs.VanillaEnemies.Martians;
+using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
@@ -36,6 +37,11 @@ namespace FargowiltasSouls.Content.Projectiles.Minions
             Player player = Main.player[Projectile.owner];
             FargoSoulsPlayer modPlayer = player.FargoSouls();
 
+            bool forcePalm = modPlayer.ForceEffect(modPlayer.PalmEnchantItem.type);
+
+            //BIG palm sentry!
+            Projectile.scale = forcePalm ? 2 : 1;
+
             if (!(player.active && !player.dead && modPlayer.PalmEnchantItem != null))
             {
                 Projectile.Kill();
@@ -49,12 +55,7 @@ namespace FargowiltasSouls.Content.Projectiles.Minions
 
             Projectile.ai[1] += 1f;
 
-            int attackRate = 45;
-
-            if (modPlayer.ForceEffect(modPlayer.PalmEnchantItem.type))
-            {
-                attackRate = 35;
-            }
+            int attackRate = forcePalm ? 30 : 45;
 
             if (Projectile.ai[1] >= attackRate)
             {

--- a/Content/Projectiles/Souls/CopperLightning.cs
+++ b/Content/Projectiles/Souls/CopperLightning.cs
@@ -217,7 +217,7 @@ namespace FargowiltasSouls.Content.Projectiles.Souls
                     //Projectile.Center = closestNPC.Center; //help ensure it hits
                     //Projectile.netUpdate = true;
 
-                    Projectile.NewProjectile(Projectile.GetSource_FromThis(), target.Center, velocity, Projectile.type, Projectile.damage, Projectile.knockBack, Projectile.owner, ai0, spawnedDamage);
+                    Projectile.NewProjectile(Projectile.GetSource_FromThis(), target.Center, velocity, Projectile.type, Projectile.damage * 17/20, Projectile.knockBack, Projectile.owner, ai0, spawnedDamage);
                     Main.player[Projectile.owner].ownedProjectileCounts[Projectile.type]++;
 
                     //ensure it hits.. ?

--- a/Core/ModPlayers/FargoSoulsPlayer.cs
+++ b/Core/ModPlayers/FargoSoulsPlayer.cs
@@ -1333,16 +1333,16 @@ namespace FargowiltasSouls.Core.ModPlayers
             {
                 bool forceEffect = ForceEffect(ModContent.ItemType<SquireEnchant>()) || ForceEffect(ModContent.ItemType<ValhallaKnightEnchant>());
                 if (Eternity)
-                    bonus = 4f;
+                    bonus = 5f;
                 else if (forceEffect && ValhallaEnchantItem != null)
-                    bonus = 1f / 5f;
+                    bonus = 1.2f;
                 else if (ValhallaEnchantItem != null || (forceEffect && SquireEnchantItem != null))
-                    bonus = 3f / 20f;
+                    bonus = 1.15f;
                 else if (SquireEnchantItem != null)
-                    bonus = 1f / 10f;
+                    bonus = 1.10f;
             }
 
-            heal = (int)(heal * (1f + bonus));
+            heal = (int)(heal * bonus);
 
             return heal;
         }

--- a/Core/ModPlayers/FargoSoulsPlayer.cs
+++ b/Core/ModPlayers/FargoSoulsPlayer.cs
@@ -1335,11 +1335,11 @@ namespace FargowiltasSouls.Core.ModPlayers
                 if (Eternity)
                     bonus = 4f;
                 else if (forceEffect && ValhallaEnchantItem != null)
-                    bonus = 1f / 2f;
+                    bonus = 1f / 5f;
                 else if (ValhallaEnchantItem != null || (forceEffect && SquireEnchantItem != null))
-                    bonus = 1f / 3f;
+                    bonus = 3f / 20f;
                 else if (SquireEnchantItem != null)
-                    bonus = 1f / 4f;
+                    bonus = 1f / 10f;
             }
 
             heal = (int)(heal * (1f + bonus));

--- a/Localization/en-US.hjson
+++ b/Localization/en-US.hjson
@@ -65,13 +65,13 @@ Mods: {
 			Stardust: Timestop cooldown decreased from 60 to 50
 			Snow: No upgrade
 			Shadow: Number of Shadow Orbs increased
-			Squire: Mount defense increased from 10 to 15, speed and acceleration from 1.25x to 1.5x, heal bonus from 25% to 33%
+			Squire: Mount defense increased from 10 to 15, speed and acceleration from 1.25x to 1.5x, heal bonus from 10% to 15%
 			Tiki: Increases whip range by 20%
 			Tin: Minimum crit increased to 10%, max crit is at least 50%, reduced proc cooldown
 			Titanium: Shard damage increased, Titanium Shield duration increased to 5 seconds and damage resistance increased to 75%
-			Tungsten: Increased weapon size increase to 200%, bonus damage to 15%, cooldown reduced
+			Tungsten: Weapon size tripled instead of doubled, melee speed penalty removed, and cooldown reduced
 			Turtle: Occasionally recover a projectile block point, number of needles and damage increased
-			ValhallaKnight: Mount defense increased from 15 to 20, acceleration from 1.5x to 2x, and heal bonus from 33% to 50%
+			ValhallaKnight: Mount defense increased from 15 to 20, acceleration from 1.5x to 2x, and heal bonus from 15% to 20%
 			Vortex: No upgrade
 			Wood: Bestiary and banner multiplier increased to 5
 			AshWood: Fires balls of fire more often
@@ -1968,6 +1968,7 @@ Mods: {
 					While you're burning, attacks are accompanied by balls of fire
 					Grants immunity to Oiled
 					Reduces damage from touching lava
+					'You're telling me this isn't wood?'
 					'''
 			}
 
@@ -2515,7 +2516,7 @@ Mods: {
 					'''
 					Increases mount acceleration, top speed, and jump height
 					While mounted, grants 10 defense, a fart jump, and fall damage immunity
-					Increases the effectiveness of healing sources by 25%
+					Increases the effectiveness of healing sources by 10%
 					Ballista pierces more targets and panics when you take damage
 					'Squire, will you hurry?'
 					'''
@@ -2568,9 +2569,9 @@ Mods: {
 				DisplayName: Tungsten Enchantment
 				Tooltip:
 					'''
-					100% increased weapon size but reduces melee speed
+					Doubles weapon size but reduces melee speed
 					Once every 2/3 of a second a projectile will be doubled in size
-					Enlarged projectiles and non-projectile swords deal 10% more damage and have an additional chance to crit
+					Enlarged projectiles and non-projectile swords deal 15% more damage
 					'Bigger is always better'
 					'''
 			}
@@ -2595,7 +2596,7 @@ Mods: {
 					'''
 					Increases mount acceleration, top speed, and jump height
 					While mounted, grants 15 defense, a fart jump, fall damage immunity, and dash
-					Increases the effectiveness of healing sources by 33%
+					Increases the effectiveness of healing sources by 15%
 					Greatly enhances Ballista effectiveness
 					'Valhalla calls'
 					'''
@@ -2832,7 +2833,7 @@ Mods: {
 					[i:FargowiltasSouls/GladiatorEnchant] Double tap down to place a banner that buffs you while close
 					[i:FargowiltasSouls/GladiatorEnchant] Spears will rain down on struck enemies
 					[i:FargowiltasSouls/RedRidingEnchant] Successive attacks gain bonus damage 
-					[i:FargowiltasSouls/ValhallaKnightEnchant] Increases the effectiveness of healing sources by 50%
+					[i:FargowiltasSouls/ValhallaKnightEnchant] Increases the effectiveness of healing sources by 25%
 					[i:FargowiltasSouls/ValhallaKnightEnchant] Improves mounts and stats while mounted, mounts have a dash
 					'A mind of unbreakable determination'
 					'''

--- a/Localization/en-US.hjson
+++ b/Localization/en-US.hjson
@@ -21,7 +21,7 @@ Mods: {
 			Cactus: Number of needles and damage increased
 			Chlorophyte: Damage of ring and spores increased, cooldown of spores reduced
 			Cobalt: On-hit explosion damage increased
-			Copper: Lightning damage increased, cooldown reduced
+			Copper: Lightning damage increased to 200, cooldown reduced
 			Crimson: No upgrade
 			CrystalAssassin: No upgrade
 			DarkArtist: The next 3 weapons are used instead of 2
@@ -47,7 +47,7 @@ Mods: {
 			Obsidian: You no longer need lava to spawn explosions or fireballs, cooldown reduced
 			Orichalcum: Increases multiplier to 4x
 			Palladium: Rapid Healing always lasts 5 seconds, increases orb damage
-			PalmWood: Attack speed and damage increased, another tree can be spawned
+			PalmWood: Attack speed, damage, and size increased
 			Pearlwood: Damage increased and cooldown reduced
 			Platinum: No upgrade
 			Pumpkin: Pumpkins can grow while flying, heal for twice as much, and flame damage is increased to 45

--- a/Localization/es-ES.hjson
+++ b/Localization/es-ES.hjson
@@ -65,13 +65,13 @@ Mods: {
 			// Stardust: Timestop cooldown decreased from 60 to 50
 			// Snow: No upgrade
 			// Shadow: Number of Shadow Orbs increased
-			// Squire: Mount defense increased from 10 to 15, speed and acceleration from 1.25x to 1.5x, heal bonus from 25% to 33%
+			// Squire: Mount defense increased from 10 to 15, speed and acceleration from 1.25x to 1.5x, heal bonus from 10% to 15%
 			// Tiki: Increases whip range by 20%
 			// Tin: Minimum crit increased to 10%, max crit is at least 50%, reduced proc cooldown
 			// Titanium: Shard damage increased, Titanium Shield duration increased to 5 seconds and damage resistance increased to 75%
-			// Tungsten: Increased weapon size increase to 200%, bonus damage to 15%, cooldown reduced
+			// Tungsten: Weapon size tripled instead of doubled, bonus damage increased to 20%, melee speed penalty removed, and cooldown reduced
 			// Turtle: Occasionally recover a projectile block point, number of needles and damage increased
-			// ValhallaKnight: Mount defense increased from 15 to 20, acceleration from 1.5x to 2x, and heal bonus from 33% to 50%
+			// ValhallaKnight: Mount defense increased from 15 to 20, acceleration from 1.5x to 2x, and heal bonus from 15% to 20%
 			// Vortex: No upgrade
 			// Wood: Bestiary and banner multiplier increased to 5
 			// AshWood: Fires balls of fire more often
@@ -1968,6 +1968,7 @@ Mods: {
 					While you're burning, attacks are accompanied by balls of fire
 					Grants immunity to Oiled
 					Reduces damage from touching lava
+					'You're telling me this isn't wood?'
 					''' */
 			}
 
@@ -2515,7 +2516,7 @@ Mods: {
 					'''
 					Increases mount acceleration, top speed, and jump height
 					While mounted, grants 10 defense, a fart jump, and fall damage immunity
-					Increases the effectiveness of healing sources by 25%
+					Increases the effectiveness of healing sources by 10%
 					Ballista pierces more targets and panics when you take damage
 					'Squire, will you hurry?'
 					''' */
@@ -2568,9 +2569,9 @@ Mods: {
 				// DisplayName: Tungsten Enchantment
 				/* Tooltip:
 					'''
-					100% increased weapon size but reduces melee speed
+					Doubles weapon size but reduces melee speed
 					Once every 2/3 of a second a projectile will be doubled in size
-					Enlarged projectiles and non-projectile swords deal 10% more damage and have an additional chance to crit
+					Enlarged projectiles and non-projectile swords deal 15% more damage
 					'Bigger is always better'
 					''' */
 			}
@@ -2595,7 +2596,7 @@ Mods: {
 					'''
 					Increases mount acceleration, top speed, and jump height
 					While mounted, grants 15 defense, a fart jump, fall damage immunity, and dash
-					Increases the effectiveness of healing sources by 33%
+					Increases the effectiveness of healing sources by 15%
 					Greatly enhances Ballista effectiveness
 					'Valhalla calls'
 					''' */
@@ -2832,7 +2833,7 @@ Mods: {
 					[i:FargowiltasSouls/GladiatorEnchant] Double tap down to place a banner that buffs you while close
 					[i:FargowiltasSouls/GladiatorEnchant] Spears will rain down on struck enemies
 					[i:FargowiltasSouls/RedRidingEnchant] Successive attacks gain bonus damage 
-					[i:FargowiltasSouls/ValhallaKnightEnchant] Increases the effectiveness of healing sources by 50%
+					[i:FargowiltasSouls/ValhallaKnightEnchant] Increases the effectiveness of healing sources by 25%
 					[i:FargowiltasSouls/ValhallaKnightEnchant] Improves mounts and stats while mounted, mounts have a dash
 					'A mind of unbreakable determination'
 					''' */

--- a/Localization/es-ES.hjson
+++ b/Localization/es-ES.hjson
@@ -69,7 +69,7 @@ Mods: {
 			// Tiki: Increases whip range by 20%
 			// Tin: Minimum crit increased to 10%, max crit is at least 50%, reduced proc cooldown
 			// Titanium: Shard damage increased, Titanium Shield duration increased to 5 seconds and damage resistance increased to 75%
-			// Tungsten: Weapon size tripled instead of doubled, bonus damage increased to 20%, melee speed penalty removed, and cooldown reduced
+			// Tungsten: Weapon size tripled instead of doubled, melee speed penalty removed, and cooldown reduced
 			// Turtle: Occasionally recover a projectile block point, number of needles and damage increased
 			// ValhallaKnight: Mount defense increased from 15 to 20, acceleration from 1.5x to 2x, and heal bonus from 15% to 20%
 			// Vortex: No upgrade

--- a/Localization/pt-BR.hjson
+++ b/Localization/pt-BR.hjson
@@ -65,13 +65,13 @@ Mods: {
 			// Stardust: Timestop cooldown decreased from 60 to 50
 			// Snow: No upgrade
 			// Shadow: Number of Shadow Orbs increased
-			// Squire: Mount defense increased from 10 to 15, speed and acceleration from 1.25x to 1.5x, heal bonus from 25% to 33%
+			// Squire: Mount defense increased from 10 to 15, speed and acceleration from 1.25x to 1.5x, heal bonus from 10% to 15%
 			// Tiki: Increases whip range by 20%
 			// Tin: Minimum crit increased to 10%, max crit is at least 50%, reduced proc cooldown
 			// Titanium: Shard damage increased, Titanium Shield duration increased to 5 seconds and damage resistance increased to 75%
-			// Tungsten: Increased weapon size increase to 200%, bonus damage to 15%, cooldown reduced
+			// Tungsten: Weapon size tripled instead of doubled, bonus damage increased to 20%, melee speed penalty removed, and cooldown reduced
 			// Turtle: Occasionally recover a projectile block point, number of needles and damage increased
-			// ValhallaKnight: Mount defense increased from 15 to 20, acceleration from 1.5x to 2x, and heal bonus from 33% to 50%
+			// ValhallaKnight: Mount defense increased from 15 to 20, acceleration from 1.5x to 2x, and heal bonus from 15% to 20%
 			// Vortex: No upgrade
 			// Wood: Bestiary and banner multiplier increased to 5
 			// AshWood: Fires balls of fire more often
@@ -1970,6 +1970,7 @@ Mods: {
 					While you're burning, attacks are accompanied by balls of fire
 					Grants immunity to Oiled
 					Reduces damage from touching lava
+					'You're telling me this isn't wood?'
 					''' */
 			}
 

--- a/Localization/pt-BR.hjson
+++ b/Localization/pt-BR.hjson
@@ -69,7 +69,7 @@ Mods: {
 			// Tiki: Increases whip range by 20%
 			// Tin: Minimum crit increased to 10%, max crit is at least 50%, reduced proc cooldown
 			// Titanium: Shard damage increased, Titanium Shield duration increased to 5 seconds and damage resistance increased to 75%
-			// Tungsten: Weapon size tripled instead of doubled, bonus damage increased to 20%, melee speed penalty removed, and cooldown reduced
+			// Tungsten: Weapon size tripled instead of doubled, melee speed penalty removed, and cooldown reduced
 			// Turtle: Occasionally recover a projectile block point, number of needles and damage increased
 			// ValhallaKnight: Mount defense increased from 15 to 20, acceleration from 1.5x to 2x, and heal bonus from 15% to 20%
 			// Vortex: No upgrade

--- a/Localization/zh-Hans.hjson
+++ b/Localization/zh-Hans.hjson
@@ -65,13 +65,13 @@ Mods: {
 			// Stardust: Timestop cooldown decreased from 60 to 50
 			// Snow: No upgrade
 			// Shadow: Number of Shadow Orbs increased
-			// Squire: Mount defense increased from 10 to 15, speed and acceleration from 1.25x to 1.5x, heal bonus from 25% to 33%
+			// Squire: Mount defense increased from 10 to 15, speed and acceleration from 1.25x to 1.5x, heal bonus from 10% to 15%
 			// Tiki: Increases whip range by 20%
 			Tin: 最小暴击率提高到10%，最大暴击率至少有50%，减少了增加暴击过程的冷却时间
 			Titanium: 碎片伤害增加，钛金护盾持续时间提高到5秒，伤害减免提高至75%
 			Tungsten: 将武器大小提升到300%，伤害加成提升到20%，冷却时间减少
 			// Turtle: Occasionally recover a projectile block point, number of needles and damage increased
-			// ValhallaKnight: Mount defense increased from 15 to 20, acceleration from 1.5x to 2x, and heal bonus from 33% to 50%
+			// ValhallaKnight: Mount defense increased from 15 to 20, acceleration from 1.5x to 2x, and heal bonus from 15% to 20%
 			// Vortex: No upgrade
 			Wood: 怪物图鉴和旗帜解锁速度从2倍变为5倍
 			// AshWood: Fires balls of fire more often
@@ -1964,6 +1964,7 @@ Mods: {
 					While you're burning, attacks are accompanied by balls of fire
 					Grants immunity to Oiled
 					Reduces damage from touching lava
+					'You're telling me this isn't wood?'
 					''' */
 			}
 


### PR DESCRIPTION
palm wood unfinished zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz im eepy

squire
squire bonus 25%>10%
wiz squire/val bonus 33%>15%
wiz val bonus 50>20%

tungsten
crit reroll DEAD
base tungsten damage bonus 10>15
wiz damage bonus doesn't exist
however, removed melee speed penalty in wiz tungsten ench (!! )

palm wood WIZARD
increased size, broken rn goes in ground someone fix what he fuck
attack speed buffed from every 35f to every 30f
*removed 2nd sentry*

copper
damage increased from 35/150 to 50/200
every time it hits enemy, reduce damage by 15%