### PR TITLE
Wizard Enchantment now works with modded slots

### DIFF
--- a/Common/EModeAccessorySlot.cs
+++ b/Common/EModeAccessorySlot.cs
@@ -58,16 +58,6 @@ namespace FargowiltasSouls.Common
         //public override string FunctionalBackgroundTexture => "FargowiltasSouls/Assets/UI/EnchantSlotBackground";
         //public override string VanityBackgroundTexture => "FargowiltasSouls/Assets/UI/EnchantSlotBackground";
         //public override string DyeBackgroundTexture => "FargowiltasSouls/Assets/UI/EnchantSlotBackground";
-        public override void ApplyEquipEffects()
-        {
-            int lastAccIndex = 7 + Player.GetAmountOfExtraAccessorySlotsToShow();
-            if (Player.armor[lastAccIndex].type == ModContent.ItemType<WizardEnchant>() || Player.armor[lastAccIndex].type == ModContent.ItemType<CosmoForce>())
-            {
-                Player.FargoSouls().WizardedItem = FunctionalItem;
-            }
-
-            base.ApplyEquipEffects();
-        }
         public override void OnMouseHover(AccessorySlotType context)
         {
             switch (context)

--- a/Core/ModPlayers/FargoSoulsPlayer.cs
+++ b/Core/ModPlayers/FargoSoulsPlayer.cs
@@ -22,6 +22,7 @@ using Terraria.Graphics.Shaders;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
+using Terraria.ModLoader.Default;
 using Terraria.ModLoader.IO;
 using static FargowiltasSouls.Core.Systems.DashManager;
 
@@ -403,12 +404,21 @@ namespace FargowiltasSouls.Core.ModPlayers
             if (WizardEnchantActive)
             {
                 WizardEnchantActive = false;
-                for (int i = 3; i <= 9; i++)
+                List<Item> accessories = [];
+                for (int i = 3; i < 10; i++)
+                    if (Player.IsItemSlotUnlockedAndUsable(i))
+                        accessories.Add(Player.armor[i]);
+                AccessorySlotLoader loader = LoaderManager.Get<AccessorySlotLoader>();
+                ModAccessorySlotPlayer modSlotPlayer = Player.GetModPlayer<ModAccessorySlotPlayer>();
+                for (int i = 0; i < modSlotPlayer.SlotCount; i++)
+                    if (loader.ModdedIsItemSlotUnlockedAndUsable(i, Player))
+                        accessories.Add(loader.Get(i, Player).FunctionalItem);
+                for (int i = 0; i < accessories.Count - 1; i++)
                 {
-                    if (!Player.armor[i].IsAir && (Player.armor[i].type == ModContent.ItemType<WizardEnchant>() || Player.armor[i].type == ModContent.ItemType<CosmoForce>()))
+                    if (!accessories[i].IsAir && (accessories[i].type == ModContent.ItemType<WizardEnchant>() || accessories[i].type == ModContent.ItemType<CosmoForce>()))
                     {
                         WizardEnchantActive = true;
-                        Item ench = Player.armor[i + 1];
+                        Item ench = accessories[i + 1];
                         if (ench != null && !ench.IsAir && ench.ModItem != null && ench.ModItem is BaseEnchant)
                         {
                             WizardedItem = ench;


### PR DESCRIPTION
Tested with Calamity's Celestial Onion slot. `EModeAccessorySlot` doesn't need to override `ApplyEquipEffects` anymore.