### PR TITLE
Balance changes for a few Mage weapons

### DIFF
--- a/Content/Items/EModeItemBalance.cs
+++ b/Content/Items/EModeItemBalance.cs
@@ -159,12 +159,17 @@ namespace FargowiltasSouls.Content.Items
                     balanceNumber = 0.88f;
                     return EModeChange.Nerf;
 
+                case ItemID.BeeGun:
+                    balanceTextKeys = ["Damage"];
+                    balanceNumber = 1.3f;
+                    return EModeChange.Buff;
+
                 case ItemID.MagicDagger:
                     {
                         if (!Main.hardMode)
                         {
                             balanceTextKeys = ["Damage", "Speed"];
-                            balanceNumber = 0.65f;
+                            balanceNumber = 0.5f;
                             return EModeChange.Nerf;
                         }
                         return EModeChange.None;

--- a/Content/Items/Weapons/BossDrops/DarkTome.cs
+++ b/Content/Items/Weapons/BossDrops/DarkTome.cs
@@ -14,7 +14,7 @@ namespace FargowiltasSouls.Content.Items.Weapons.BossDrops
         public override void SetDefaults()
         {
             Item.noMelee = true;
-            Item.damage = 31;
+            Item.damage = 28;
             Item.DamageType = DamageClass.Magic;
             Item.mana = 30;
             Item.rare = ItemRarityID.Orange;


### PR DESCRIPTION
Dark Tome damage: 31 -> 28
Magic Dagger nerf multiplier: 0.65x -> 0.5x
Bee Gun new damage multiplier: 1.3x