### PR TITLE
tree sword no longer uses the trojan acorn noise

### DIFF
--- a/Content/Bosses/Champions/Timber/TimberAcorn.cs
+++ b/Content/Bosses/Champions/Timber/TimberAcorn.cs
@@ -35,7 +35,7 @@ namespace FargowiltasSouls.Content.Bosses.Champions.Timber
             if (Projectile.localAI[0] == 0f)
             {
                 Projectile.localAI[0] = 1f;
-                SoundEngine.PlaySound(FargosSoundRegistry.TrojanCannon, Projectile.position);
+                //SoundEngine.PlaySound(FargosSoundRegistry.TrojanCannon, Projectile.position);
             }
             Projectile.velocity.Y += 0.2f;
 

--- a/Content/Bosses/Champions/Timber/TimberChampion.cs
+++ b/Content/Bosses/Champions/Timber/TimberChampion.cs
@@ -1,4 +1,5 @@
-﻿using FargowiltasSouls.Content.Buffs.Masomode;
+﻿using FargowiltasSouls.Assets.Sounds;
+using FargowiltasSouls.Content.Buffs.Masomode;
 using FargowiltasSouls.Content.Items.Accessories.Forces;
 using FargowiltasSouls.Content.Items.Placables.Relics;
 using FargowiltasSouls.Core.Globals;
@@ -277,6 +278,7 @@ namespace FargowiltasSouls.Content.Bosses.Champions.Timber
                             Projectile.NewProjectile(NPC.GetSource_FromThis(), NPC.Center, distance + Main.rand.NextVector2Square(-0.5f, 0.5f) * 3,
                                 ModContent.ProjectileType<TimberAcorn>(), FargoSoulsUtil.ScaledProjectileDamage(NPC.defDamage, 0.8f), 0f, Main.myPlayer);
                         }
+                        SoundEngine.PlaySound(FargosSoundRegistry.TrojanCannon, NPC.Center);
                     }
 
                     NPC.localAI[0] = 0;

--- a/Content/Bosses/TrojanSquirrel/TrojanSquirrelHead.cs
+++ b/Content/Bosses/TrojanSquirrel/TrojanSquirrelHead.cs
@@ -112,6 +112,7 @@ namespace FargowiltasSouls.Content.Bosses.TrojanSquirrel
                             {
                                 if (FargoSoulsUtil.HostCheck)
                                 {
+                                    SoundEngine.PlaySound(FargosSoundRegistry.TrojanCannon, pos);
                                     Projectile.NewProjectile(NPC.GetSource_FromThis(), pos, distance + Main.rand.NextVector2Square(-0.5f, 0.5f),
                                         ModContent.ProjectileType<TrojanAcorn>(), FargoSoulsUtil.ScaledProjectileDamage(NPC.defDamage), 0f, Main.myPlayer);
                                 }

--- a/Content/Items/Weapons/BossDrops/RefractorBlaster.cs
+++ b/Content/Items/Weapons/BossDrops/RefractorBlaster.cs
@@ -48,13 +48,13 @@ namespace FargowiltasSouls.Content.Items.Weapons.BossDrops
             {
                 Vector2 newVelocity = velocity.RotatedBy(MathHelper.ToRadians(28 + Main.rand.NextFloat(1f, 35f)));
                 newVelocity *= 1f - Main.rand.NextFloat(0.3f);
-                Projectile.NewProjectileDirect(source, position, newVelocity, type, damage, knockback, player.whoAmI);
+                Projectile.NewProjectileDirect(source, position, newVelocity, type, damage, knockback, player.whoAmI, 0, 1);
             }
             for (int i = 0; i < NumProjectiles; i++)
             {
                 Vector2 newVelocity = velocity.RotatedBy(MathHelper.ToRadians(-28 + Main.rand.NextFloat(-1f, -35f)));
                 newVelocity *= 1f - Main.rand.NextFloat(0.3f);
-                Projectile.NewProjectileDirect(source, position, newVelocity, type, damage, knockback, player.whoAmI);
+                Projectile.NewProjectileDirect(source, position, newVelocity, type, damage, knockback, player.whoAmI, 0, 1);
             }
 
             return false; // Return false because we don't want tModLoader to shoot projectile

--- a/Content/Items/Weapons/SwarmDrops/GeminiGlaives.cs
+++ b/Content/Items/Weapons/SwarmDrops/GeminiGlaives.cs
@@ -69,13 +69,13 @@ namespace FargowiltasSouls.Content.Items.Weapons.SwarmDrops
             return true;
         }
 
-        public override bool CanShoot(Player player) => true; //player.ownedProjectileCounts[ModContent.ProjectileType<Retiglaive>()] <= 0 && player.ownedProjectileCounts[ModContent.ProjectileType<Spazmaglaive>()] <= 0;
+        public override bool CanShoot(Player player) => player.ownedProjectileCounts[ModContent.ProjectileType<Retiglaive>()] <= 0 || player.ownedProjectileCounts[ModContent.ProjectileType<Spazmaglaive>()] <= 0;
 
-        public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback)
+        /*public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback)
         {
             if (lastThrown != type)
                 damage = (int)(damage * 1.5); //additional damage boost for switching
-        }
+        }*/
 
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
         {

--- a/Content/Projectiles/BossWeapons/PrimeLaser.cs
+++ b/Content/Projectiles/BossWeapons/PrimeLaser.cs
@@ -62,11 +62,15 @@ namespace FargowiltasSouls.Content.Projectiles.BossWeapons
         public override void ModifyHitNPC(NPC target, ref NPC.HitModifiers modifiers)
         {
             float chargeupTime = 10;
-            if (Projectile.ai[0] < chargeupTime)
+            if (Projectile.ai[1] == 1)
             {
-                float modifier = Projectile.ai[0] / chargeupTime;
-                modifiers.SourceDamage *= 0.4f + 0.6f * modifier;
+                if (Projectile.ai[0] < chargeupTime)
+                {
+                    float modifier = Projectile.ai[0] / chargeupTime;
+                    modifiers.SourceDamage *= 0.4f + 0.6f * modifier;
+                }
             }
+            
             base.ModifyHitNPC(target, ref modifiers);
         }
         public override void OnKill(int timeLeft)

--- a/Content/Projectiles/BossWeapons/Retirang.cs
+++ b/Content/Projectiles/BossWeapons/Retirang.cs
@@ -43,6 +43,7 @@ namespace FargowiltasSouls.Content.Projectiles.BossWeapons
             Projectile.penetrate = 1;
             Projectile.aiStyle = -1;
             Projectile.tileCollide = false;
+            Projectile.FargoSouls().CanSplit = false;
         }
       
 
@@ -94,6 +95,7 @@ namespace FargowiltasSouls.Content.Projectiles.BossWeapons
                             {
                                 Main.projectile[p].DamageType = DamageClass.Melee;
                                 Main.projectile[p].tileCollide = false;
+                                ProjectileID.Sets.CultistIsResistantTo[p] = true;
                                 
                             }
 

--- a/Content/Projectiles/BossWeapons/Spazmaglaive.cs
+++ b/Content/Projectiles/BossWeapons/Spazmaglaive.cs
@@ -27,6 +27,7 @@ namespace FargowiltasSouls.Content.Projectiles.BossWeapons
             // DisplayName.SetDefault("Spazmaglaive");
             ProjectileID.Sets.TrailCacheLength[Projectile.type] = 10;
             ProjectileID.Sets.TrailingMode[Projectile.type] = 2;
+            ProjectileID.Sets.CultistIsResistantTo[Projectile.type] = true;
         }
 
         public override void SendExtraAI(BinaryWriter writer)
@@ -98,7 +99,7 @@ namespace FargowiltasSouls.Content.Projectiles.BossWeapons
 
             if (Projectile.ai[0] == 1 && empowered)
             {
-                NPC n = FargoSoulsUtil.NPCExists(FargoSoulsUtil.FindClosestHostileNPC(Projectile.Center, 1200, false, true));
+                NPC n = FargoSoulsUtil.NPCExists(FargoSoulsUtil.FindClosestHostileNPC(Projectile.Center, 2400, false, true));
                 if (n.Alive())
                 {   
                     if (hitSomething == false)


### PR DESCRIPTION
differentiated retirang and gemini lasers from refractor lasers using projectile.ai[1] improved spazmaglaive homing range
retirang lasers and spazmaglaive now have the homing tag