### PR TITLE
Mostly fixes and softcap introduction (read desc.)

### DIFF
--- a/Common/Utilities/FargoExtensionMethods.cs
+++ b/Common/Utilities/FargoExtensionMethods.cs
@@ -191,7 +191,7 @@ namespace FargowiltasSouls //lets everything access it without using
         /// <param name="damageClass"></param>
         /// <returns></returns>
         public static float ActualClassCrit(this Player player, DamageClass damageClass)
-            => damageClass == DamageClass.Summon
+            => damageClass == DamageClass.Summon || damageClass == DamageClass.SummonMeleeSpeed
             && !(player.FargoSouls().MinionCrits)
             ? 0
             : player.GetTotalCritChance(damageClass);

--- a/Content/Items/Accessories/Enchantments/AshWoodEnchant.cs
+++ b/Content/Items/Accessories/Enchantments/AshWoodEnchant.cs
@@ -93,21 +93,26 @@ namespace FargowiltasSouls.Content.Items.Accessories.Enchantments
             {
                 modPlayer.AshwoodCD = modPlayer.ForceEffect<AshWoodEnchant>() ? 20 : player.HasEffect<ObsidianProcEffect>() ? 25 : 35;
 
-                int cap = 60;
+                float softcapMult = 2f;
                 int effectItemType = EffectItem(player).type;
+                Item heldItem = player.HeldItem;
                 int ashwood = ModContent.ItemType<AshWoodEnchant>();
                 int obsidian = ModContent.ItemType<ObsidianEnchant>();
                 if (!player.ForceEffect<AshWoodFireballs>() && (effectItemType == ashwood || effectItemType == obsidian))
-                    cap = 30;
+                    softcapMult = 1f;
 
-                int fireballDamage = damage;
+                float fireballDamage = damage;
+                if (!modPlayer.TerrariaSoul && heldItem != null && heldItem.IsWeaponWithDamageClass())
+                {
+                    fireballDamage *= player.ActualClassDamage(DamageClass.Magic);
+                    if (fireballDamage > 30f * softcapMult)
+                    fireballDamage = (float)Math.Round(((60f * softcapMult) + fireballDamage) / 3f);
+                }
                 Vector2 vel = Vector2.Normalize(Main.MouseWorld - player.Center) * 17f;
                 vel = vel.RotatedByRandom(Math.PI / 10);
-                if (!modPlayer.TerrariaSoul)
-                    fireballDamage = Math.Min(fireballDamage, FargoSoulsUtil.HighestDamageTypeScaling(player, cap));
 
                 if (player.whoAmI == Main.myPlayer)
-                    Projectile.NewProjectile(GetSource_EffectItem(player), player.Center, vel, ProjectileID.BallofFire, fireballDamage, 1, Main.myPlayer);
+                    Projectile.NewProjectile(GetSource_EffectItem(player), player.Center, vel, ProjectileID.BallofFire, (int)fireballDamage, 1, Main.myPlayer);
             }
         }
     }

--- a/Content/Items/Accessories/Enchantments/GladiatorEnchant.cs
+++ b/Content/Items/Accessories/Enchantments/GladiatorEnchant.cs
@@ -140,15 +140,22 @@ namespace FargowiltasSouls.Content.Items.Accessories.Enchantments
                 bool force = modPlayer.ForceEffect<GladiatorEnchant>();
 
                 bool buff = player.HasBuff<GladiatorBuff>();
-                int spearDamage = baseDamage / (buff ? 3 : 5);
+                float spearDamage = baseDamage / (buff ? 3f : 5f);
+                spearDamage *= player.ActualClassDamage(DamageClass.Ranged) / player.ActualClassDamage(hitInfo.DamageType);
+                spearDamage = (float)Math.Round(spearDamage);
 
                 if (force)
                     spearDamage *= 2;
 
-                if (spearDamage > 0)
+                if ((int)spearDamage > 0)
                 {
                     if (!modPlayer.TerrariaSoul)
-                        spearDamage = Math.Min(spearDamage, FargoSoulsUtil.HighestDamageTypeScaling(player, 300));
+                    {
+                        float softcapMult = force ? 5f : 1f;
+                        if (spearDamage > (10f * softcapMult))
+                            spearDamage = ((20f * softcapMult) + spearDamage) / 3f; // refer to Boreal Wood Enchantment for new softcap
+                    }
+
                     Item effectItem = EffectItem(player);
                     for (int i = 0; i < 3; i++)
                     {
@@ -160,7 +167,7 @@ namespace FargowiltasSouls.Content.Items.Accessories.Enchantments
                         //speed.Normalize();
                         //speed *= 15f * Main.rand.NextFloat(0.8f, 1.2f);
 
-                        Projectile.NewProjectile(player.GetSource_Accessory(effectItem), spawn, Vector2.Normalize(aim - spawn).RotatedByRandom(MathHelper.Pi / 20) * speed, ModContent.ProjectileType<GladiatorJavelin>(), spearDamage, 4f, Main.myPlayer);
+                        Projectile.NewProjectile(player.GetSource_Accessory(effectItem), spawn, Vector2.Normalize(aim - spawn).RotatedByRandom(MathHelper.Pi / 20) * speed, ModContent.ProjectileType<GladiatorJavelin>(), (int)spearDamage, 4f, Main.myPlayer);
                     }
 
                     modPlayer.GladiatorCD = force ? 10 : 30;

--- a/Content/Items/Accessories/Enchantments/ObsidianEnchant.cs
+++ b/Content/Items/Accessories/Enchantments/ObsidianEnchant.cs
@@ -106,20 +106,22 @@ namespace FargowiltasSouls.Content.Items.Accessories.Enchantments
                 return;
             if (player.FargoSouls().ObsidianCD == 0)
             {
-                int damage = baseDamage;
+                float explosionDamage = baseDamage;
                 FargoSoulsPlayer modPlayer = player.FargoSouls();
-                int cap = player.ForceEffect<ObsidianProcEffect>() ? 200 : 50;
-                damage = Math.Min(damage, FargoSoulsUtil.HighestDamageTypeScaling(player, cap));
+                bool force = player.ForceEffect<ObsidianProcEffect>();
+                float softcapMult = force ? 4f : 1f;
 
-                if (player.lavaWet || modPlayer.LavaWet)
-                    damage = (int)(damage * 1.3f);
-                if (!player.ForceEffect<ObsidianProcEffect>())
-                    damage = (int)(damage * 0.875f);
+                if (force) // this section is just imitating the previous version but cleaner
+                {
+                    explosionDamage *= 1.5f; // technically meant to result to 1.3f but we'll see
+                    if (!(player.lavaWet || modPlayer.LavaWet))
+                        explosionDamage *= 0.75f;
+                }
 
-                if (damage > 250)
-                    damage = 250;
+                if (explosionDamage > 50f * softcapMult)
+                    explosionDamage = ((100f * softcapMult) + explosionDamage) / 3f;
 
-                Projectile.NewProjectile(GetSource_EffectItem(player), target.Center, Vector2.Zero, ModContent.ProjectileType<ObsidianExplosion>(), damage, 0, player.whoAmI);
+                Projectile.NewProjectile(GetSource_EffectItem(player), target.Center, Vector2.Zero, ModContent.ProjectileType<ObsidianExplosion>(), (int)explosionDamage, 0, player.whoAmI);
 
                 modPlayer.ObsidianCD = 50;
             }

--- a/Content/Items/Accessories/Enchantments/ShroomiteEnchant.cs
+++ b/Content/Items/Accessories/Enchantments/ShroomiteEnchant.cs
@@ -1,4 +1,5 @@
-﻿using FargowiltasSouls.Content.Items.Accessories.Forces;
+﻿using System;
+using FargowiltasSouls.Content.Items.Accessories.Forces;
 using FargowiltasSouls.Content.Projectiles.Souls;
 using FargowiltasSouls.Core.AccessoryEffectSystem;
 using FargowiltasSouls.Core.Toggler.Content;
@@ -91,23 +92,28 @@ namespace FargowiltasSouls.Content.Items.Accessories.Enchantments
 
             if (projectile != null && (projectile.penetrate > 1 || projectile.penetrate < 0) && projectile.maxPenetrate == projectile.penetrate && projectile.type != ModContent.ProjectileType<ShroomiteShroom>())
             {
-                SpawnShrooms(player, target, baseDamage);
+                SpawnShrooms(player, target, hitInfo, baseDamage);
             }
         }
 
-        public static void SpawnShrooms(Player player, NPC target, int baseDamage)
+        public static void SpawnShrooms(Player player, NPC target, NPC.HitInfo hitInfo, int baseDamage)
         {
             FargoSoulsPlayer modPlayer = player.FargoSouls();
-            int damage = baseDamage / 4;
+            float shroomDamage = baseDamage / 4; // 0.25x or 25%
             int num = 3;
             if (modPlayer.ForceEffect<ShroomiteEnchant>())
             {
                 num = 5;
-                damage = (int)(baseDamage / 2.5f);
+                shroomDamage = baseDamage / 2.5f; // 0.4x or 40%
             }
-            if (damage > 115)
-                damage = 115;
-            Projectile[] projs = FargoSoulsUtil.XWay(num, player.GetSource_EffectItem<ShroomiteShroomEffect>(), target.Center, ModContent.ProjectileType<ShroomiteShroom>(), 16, damage, 0f);
+            if (!player.HasEffect<NatureEffect>())
+            {
+                shroomDamage *= player.ActualClassDamage(DamageClass.Ranged) / player.ActualClassDamage(hitInfo.DamageType);
+                shroomDamage = (float)Math.Round(shroomDamage);
+            }
+            if (shroomDamage > 115f)
+                shroomDamage = (230f + shroomDamage) / 3f; // refer to Boreal Wood Enchantment for new softcap
+            Projectile[] projs = FargoSoulsUtil.XWay(num, player.GetSource_EffectItem<ShroomiteShroomEffect>(), target.Center, ModContent.ProjectileType<ShroomiteShroom>(), 16, (int)shroomDamage, 0f);
 
             foreach (Projectile p in projs)
             {

--- a/Content/Items/Armor/NekomiHood.cs
+++ b/Content/Items/Armor/NekomiHood.cs
@@ -36,7 +36,7 @@ namespace FargowiltasSouls.Content.Items.Armor
         public override void UpdateEquip(Player player)
         {
             player.GetDamage(DamageClass.Generic) += 0.07f;
-            player.maxMinions += 2;
+            player.maxMinions += 1;
         }
 
         public override bool IsArmorSet(Item head, Item body, Item legs)
@@ -98,6 +98,7 @@ namespace FargowiltasSouls.Content.Items.Armor
         {
             player.GetDamage(DamageClass.Generic) += 0.07f;
             player.GetCritChance(DamageClass.Generic) += 7;
+            player.maxMinions += 1;
 
             FargoSoulsPlayer fargoPlayer = player.FargoSouls();
             fargoPlayer.Graze = true;

--- a/Content/Items/EModeItemBalance.cs
+++ b/Content/Items/EModeItemBalance.cs
@@ -525,6 +525,10 @@ namespace FargowiltasSouls.Content.Items
                     balanceTextKeys = ["Damage"];
                     balanceNumber = 1.2f;
                     return EModeChange.Buff;
+
+                case ItemID.MedusaHead:
+                    balanceTextKeys = ["MedusaHead"];
+                    return EModeChange.Buff;
                 default:
                     return EModeChange.None;
             }

--- a/Content/Projectiles/EModeGlobalProjectile.cs
+++ b/Content/Projectiles/EModeGlobalProjectile.cs
@@ -34,7 +34,7 @@ namespace FargowiltasSouls.Content.Projectiles
         public bool EModeCanHurt = true;
         public int NerfDamageBasedOnProjTypeCount;
         public bool altBehaviour;
-
+        private List<Tuple<int, float>> medusaList = typeof(Projectile).GetField("_medusaHeadTargetList", LumUtils.UniversalBindingFlags).GetValue(null) as List<Tuple<int, float>>;
         private int counter;
         private bool preAICheckDone;
         private bool firstTickAICheckDone;
@@ -1287,6 +1287,18 @@ namespace FargowiltasSouls.Content.Projectiles
 
                 case ProjectileID.OrichalcumHalberd:
                     modifiers.FinalDamage *= SpearRework.OrichalcumDoTDamageModifier(target.lifeRegen);
+                    break;
+                case ProjectileID.MedusaHeadRay:
+                    if (projectile.owner.IsWithinBounds(Main.maxPlayers))
+                    {
+                        Player player = Main.player[projectile.owner];
+                        if (player.Alive())
+                        {
+                            float maxBonus = 1.25f;                    // Medusa Head can target up to 3 enemies max, this EMode buff makes it so that
+                            float bonus = maxBonus / medusaList.Count; // for every enemy target slot that's empty, the damage goes up by +0.625x,
+                            modifiers.FinalDamage *= 1 + bonus;       // up to +1.25x, resulting in a 2.25x max bonus
+                        }
+                    }
                     break;
             }
 

--- a/Content/Projectiles/FargoSoulsGlobalProjectile.cs
+++ b/Content/Projectiles/FargoSoulsGlobalProjectile.cs
@@ -1609,7 +1609,7 @@ namespace FargowiltasSouls.Content.Projectiles
 
             if (projectile.type == ProjectileID.CrystalLeafShot && player.HasEffect<NatureEffect>() && player.HasEffect<ShroomiteShroomEffect>())
             {
-                ShroomiteShroomEffect.SpawnShrooms(player, target, (int)(damageDone * 1f));
+                ShroomiteShroomEffect.SpawnShrooms(player, target, hit, (int)(damageDone * 1f));
             }
         }
 

--- a/Localization/en-US/Mods.FargowiltasSouls.EModeBalance.hjson
+++ b/Localization/en-US/Mods.FargowiltasSouls.EModeBalance.hjson
@@ -60,3 +60,4 @@ FlowerPow: Tripled petal firerate
 PiranhaGun: Projectile damage updates dynamically
 ProximityMineLauncher: Projectile damage updates dynamically
 PygmyStaff: Spears can now pierce once
+MedusaHead: Deals up to 2.25x damage on fewer enemies

--- a/Localization/en-US/Mods.FargowiltasSouls.Items.hjson
+++ b/Localization/en-US/Mods.FargowiltasSouls.Items.hjson
@@ -229,6 +229,7 @@ GladiatorEnchant: {
 	Tooltip:
 		'''
 		Spears will rain down on struck enemies, dealing ranged damage
+		Spears ignore 5 enemy defense
 		Spear rain is stronger while close to the Gladiator Banner
 		'Are you not entertained?'
 		'''

--- a/Localization/en-US/Mods.FargowiltasSouls.SetBonus.hjson
+++ b/Localization/en-US/Mods.FargowiltasSouls.SetBonus.hjson
@@ -1,6 +1,7 @@
 Nekomi:
 	'''
 	7% increased damage and critical strike chance for your current weapon class
+	Increase max number of minions by 1
 	Increases Sparkling Adoration graze radius
 	Graze attacks to temporarily charge energy
 	Increases life regeneration when damaged at the cost of some energy

--- a/Localization/es-ES/Mods.FargowiltasSouls.EModeBalance.hjson
+++ b/Localization/es-ES/Mods.FargowiltasSouls.EModeBalance.hjson
@@ -60,3 +60,4 @@
 // PiranhaGun: Projectile damage updates dynamically
 // ProximityMineLauncher: Projectile damage updates dynamically
 // PygmyStaff: Spears can now pierce once
+// MedusaHead: Deals up to 2.25x damage on fewer enemies

--- a/Localization/es-ES/Mods.FargowiltasSouls.Items.hjson
+++ b/Localization/es-ES/Mods.FargowiltasSouls.Items.hjson
@@ -229,6 +229,7 @@ GladiatorEnchant: {
 	/* Tooltip:
 		'''
 		Spears will rain down on struck enemies, dealing ranged damage
+		Spears ignore 5 enemy defense
 		Spear rain is stronger while close to the Gladiator Banner
 		'Are you not entertained?'
 		''' */

--- a/Localization/es-ES/Mods.FargowiltasSouls.Projectiles.hjson
+++ b/Localization/es-ES/Mods.FargowiltasSouls.Projectiles.hjson
@@ -789,6 +789,6 @@
 // BoneShield.DisplayName: Bone Shield
 // BloodDroplet.DisplayName: Blood Droplet
 // BloodPuddle.DisplayName: Blood Puddle
+// VikingHook.DisplayName: Viking Hook
 // PaladinHammer.DisplayName: Paladin Hammer
 // DungeonDebris.DisplayName: Dungeon Debris
-// VikingHook.DisplayName: Viking Hook

--- a/Localization/es-ES/Mods.FargowiltasSouls.SetBonus.hjson
+++ b/Localization/es-ES/Mods.FargowiltasSouls.SetBonus.hjson
@@ -1,6 +1,7 @@
 /* Nekomi:
 	'''
 	7% increased damage and critical strike chance for your current weapon class
+	Increase max number of minions by 1
 	Increases Sparkling Adoration graze radius
 	Graze attacks to temporarily charge energy
 	Increases life regeneration when damaged at the cost of some energy

--- a/Localization/pt-BR/Mods.FargowiltasSouls.EModeBalance.hjson
+++ b/Localization/pt-BR/Mods.FargowiltasSouls.EModeBalance.hjson
@@ -60,3 +60,4 @@ IceBarrier: Modo Eternidade: 10% de redução nos danos
 // PiranhaGun: Projectile damage updates dynamically
 // ProximityMineLauncher: Projectile damage updates dynamically
 // PygmyStaff: Spears can now pierce once
+// MedusaHead: Deals up to 2.25x damage on fewer enemies

--- a/Localization/pt-BR/Mods.FargowiltasSouls.Projectiles.hjson
+++ b/Localization/pt-BR/Mods.FargowiltasSouls.Projectiles.hjson
@@ -789,6 +789,6 @@ PlasmaProj.DisplayName: Raio de Plasma
 // BoneShield.DisplayName: Bone Shield
 // BloodDroplet.DisplayName: Blood Droplet
 // BloodPuddle.DisplayName: Blood Puddle
+// VikingHook.DisplayName: Viking Hook
 // PaladinHammer.DisplayName: Paladin Hammer
 // DungeonDebris.DisplayName: Dungeon Debris
-// VikingHook.DisplayName: Viking Hook

--- a/Localization/ru-RU/Mods.FargowiltasSouls.EModeBalance.hjson
+++ b/Localization/ru-RU/Mods.FargowiltasSouls.EModeBalance.hjson
@@ -60,3 +60,4 @@ FlowerPow: Лепестки вылетают в три раза чаще
 PiranhaGun: Урон снарядов обновляется постоянно
 ProximityMineLauncher: Урон снарядов обновляется постоянно
 PygmyStaff: Spears can now pierce once
+// MedusaHead: Deals up to 2.25x damage on fewer enemies

--- a/Localization/ru-RU/Mods.FargowiltasSouls.Projectiles.hjson
+++ b/Localization/ru-RU/Mods.FargowiltasSouls.Projectiles.hjson
@@ -789,6 +789,6 @@ BoneFlail.DisplayName: Костяная булава
 BoneShield.DisplayName: Костяной щит
 // BloodDroplet.DisplayName: Blood Droplet
 // BloodPuddle.DisplayName: Blood Puddle
+// VikingHook.DisplayName: Viking Hook
 // PaladinHammer.DisplayName: Paladin Hammer
 // DungeonDebris.DisplayName: Dungeon Debris
-// VikingHook.DisplayName: Viking Hook

--- a/Localization/zh-Hans/Mods.FargowiltasSouls.EModeBalance.hjson
+++ b/Localization/zh-Hans/Mods.FargowiltasSouls.EModeBalance.hjson
@@ -60,3 +60,4 @@ FlowerPow: 花瓣发射频率增加200%
 PiranhaGun: 弹幕伤害会动态更新
 ProximityMineLauncher: 弹幕伤害会动态更新
 PygmyStaff: 长矛可以穿透一次
+// MedusaHead: Deals up to 2.25x damage on fewer enemies


### PR DESCRIPTION
Several Enchantments now use softcaps with diminishing returns and properly scale with their intended class (numbers still pending) \- Ash Wood Enchantment fireballs
\- Boreal Wood snowballs
\- Gladiator spears
\- Obsidian explosion (no intended class)
\- Shroomite shrooms
Nekomi armor Hood extra minion slot is partially moved to set bonus Medusa Head: Deals up to 2.25x damage on fewer enemies Gladiator Enchantment now mentions the spears' innate armor penetration in tooltip