### PR TITLE
Fixed typo for Heart of the Masochist having accidental capitalization

### DIFF
--- a/Localization/en-US/Mods.FargowiltasSouls.Items.hjson
+++ b/Localization/en-US/Mods.FargowiltasSouls.Items.hjson
@@ -1253,7 +1253,7 @@ HeartoftheMasochist: {
 		[i:FargowiltasSouls/PumpkingsCape] [i:FargowiltasSouls/MutantAntibodies] [i:FargowiltasSouls/IceQueensCrown] Increases damage and crit chance by 10%, and damage reduction by 5%
 		[i:FargowiltasSouls/PumpkingsCape] Guard Parry negates up to 200 damage. Parries heal you based on damage. While guarding, gain an aura of Rotting
 		[i:FargowiltasSouls/IceQueensCrown] Graze attacks to charge up Graze Bomb
-		[i:FargowiltasSouls/BetsysHeart] FIreball Dash inflicts Betsy's Curse
+		[i:FargowiltasSouls/BetsysHeart] Fireball Dash inflicts Betsy's Curse
 		[i:FargowiltasSouls/MutantAntibodies] Submerging yourself in water refreshes your flight time, and gives improved speed and max flight time
 		[i:FargowiltasSouls/MutantAntibodies] Riding Cute Fishron gives you the Wet debuff
 		[i:FargowiltasSouls/PrecisionSeal] Hold Precision Seal key to disable dashes and double jumps, and show your hurtbox


### PR DESCRIPTION
"FIreball" is now "Fireball"