### PR TITLE
Coin Gun internal tweaks:

### DIFF
--- a/Content/Projectiles/EModeGlobalProjectile.cs
+++ b/Content/Projectiles/EModeGlobalProjectile.cs
@@ -1425,7 +1425,7 @@ namespace FargowiltasSouls.Content.Projectiles
 
                 switch (projectile.type)
                 {
-                    case ProjectileID.CopperCoin:
+                    /*case ProjectileID.CopperCoin:
                         if (SourceItemType == ItemID.CoinGun && EmodeItemBalance.HasEmodeChange(player, SourceItemType))
                         {
                             modifiers.SourceDamage *= 1.6f;
@@ -1448,7 +1448,7 @@ namespace FargowiltasSouls.Content.Projectiles
                         {
                             modifiers.SourceDamage *= 0.275f;
                         }
-                        break;
+                        break;*/
 
                     case ProjectileID.OrichalcumHalberd:
                         if (SourceItemType == ItemID.OrichalcumHalberd && EmodeItemBalance.HasEmodeChange(player, SourceItemType))

--- a/FargowiltasSoulsDetours.cs
+++ b/FargowiltasSoulsDetours.cs
@@ -38,9 +38,13 @@ namespace FargowiltasSouls
 
         private static readonly MethodInfo? On_NPC_StrikeNPC_HitInfo_bool_bool_Method = typeof(NPC).GetMethod("StrikeNPC", BindingFlags.Instance | BindingFlags.Public);
 
+        private static readonly MethodInfo? On_Player_PickAmmo_Method = typeof(Player).GetMethod("PickAmmo", BindingFlags.Instance | BindingFlags.NonPublic);
+
         public delegate void Orig_CombinedHooks_ModifyHitNPCWithProj(Projectile projectile, NPC nPC, ref NPC.HitModifiers modifiers);
 
         public delegate int Orig_StrikeNPC_HitInfo_bool_bool(NPC nPC, NPC.HitInfo hit, bool fromNet, bool noPlayerInteraction);
+
+        public delegate void Orig_PickAmmo(Player self, Item sItem, ref int projToShoot, ref float speed, ref bool canShoot, ref int totalDamage, ref float KnockBack, out int usedAmmoItemId, bool dontConsume);
 
         public void LoadDetours()
         {
@@ -126,6 +130,7 @@ namespace FargowiltasSouls
         {
             HookHelper.ModifyMethodWithDetour(CombinedHooks_ModifyHitNPCWithProj_Method, CombinedHooks_ModifyHitNPCWithProj);
             HookHelper.ModifyMethodWithDetour(On_NPC_StrikeNPC_HitInfo_bool_bool_Method, UndoNinjaEnchCrit);
+            HookHelper.ModifyMethodWithDetour(On_Player_PickAmmo_Method, NerfCoinGun);
         }
 
         private static bool LifeRevitalizer_CheckSpawn_Internal(
@@ -250,7 +255,7 @@ namespace FargowiltasSouls
         public static void HorsemansBlade_SpawnPumpkin(On_Player.orig_HorsemansBlade_SpawnPumpkin orig, Player self, int npcIndex, int dmg, float kb)
         {
             NPC npc = Main.npc[npcIndex];
-            if (npc.type is NPCID.GolemFistLeft or NPCID.GolemFistRight && WorldSavingSystem.EternityMode  && npc.TryGetGlobalNPC(out GolemFist golemFist) && golemFist.RunEmodeAI)
+            if (npc.type is NPCID.GolemFistLeft or NPCID.GolemFistRight && WorldSavingSystem.EternityMode && npc.TryGetGlobalNPC(out GolemFist golemFist) && golemFist.RunEmodeAI)
                 return;
             orig(self, npcIndex, dmg, kb);
         }
@@ -292,8 +297,8 @@ namespace FargowiltasSouls
                 num2 = 0.5f;
                 string mode = WorldSavingSystem.MasochistModeReal ? Language.GetTextValue("Mods.FargowiltasSouls.UI.MasochistMode") : Language.GetTextValue("Mods.FargowiltasSouls.UI.EternityMode");
                 string text = Language.GetTextValue("Mods.FargowiltasSouls.UI.NoRespawn", mode);
-                DynamicSpriteFontExtensionMethods.DrawString(Main.spriteBatch, FontAssets.DeathText.Value, text, 
-                    new Vector2((float)(Main.screenWidth / 2) - FontAssets.DeathText.Value.MeasureString(text).X * num2 / 2, (float)(Main.screenHeight / 2) + num), 
+                DynamicSpriteFontExtensionMethods.DrawString(Main.spriteBatch, FontAssets.DeathText.Value, text,
+                    new Vector2((float)(Main.screenWidth / 2) - FontAssets.DeathText.Value.MeasureString(text).X * num2 / 2, (float)(Main.screenHeight / 2) + num),
                     Main.LocalPlayer.GetDeathAlpha(Microsoft.Xna.Framework.Color.Transparent), 0f, default, num2, SpriteEffects.None, 0f);
             }
         }
@@ -468,7 +473,7 @@ namespace FargowiltasSouls
         }
 
         public static void PhantasmArrowRainFix(On_Projectile.orig_Damage orig, Projectile self)
-        {// this detour makes it so Arrow Rain projectiles spawned from max stack Red Riding Enchantment do not proc Phantasm's phantom arrows
+        { // this detour makes it so Arrow Rain projectiles spawned from max stack Red Riding Enchantment do not proc Phantasm's phantom arrows
             if (self is not null && self.friendly && self.owner.IsWithinBounds(Main.maxPlayers) && self.owner == Main.myPlayer)
             {
                 int phantasmTime = -1;
@@ -489,14 +494,14 @@ namespace FargowiltasSouls
         }
 
         public static void ShadowDodgeNerf(On_Player.orig_PutHallowedArmorSetBonusOnCooldown orig, Player self)
-        {// hallowed dodge nerf
+        { // hallowed dodge nerf
             orig(self);
             if (EmodeItemBalance.HasEmodeChange(self, ItemID.HallowedPlateMail))
                 self.shadowDodgeTimer = 60 * 45;
         }
 
         public static int UndoNinjaEnchCrit(Orig_StrikeNPC_HitInfo_bool_bool orig, NPC self, NPC.HitInfo hit, bool fromNet, bool noPlayerInteraction)
-        {// sorry I don't wanna risk using (using static ...FargoSoulsGlobalProjectile) and make the file annoying to work with in case of ambiguous fields.
+        { // sorry I don't wanna risk using (using static ...FargoSoulsGlobalProjectile) and make the file annoying to work with in case of ambiguous fields.
             if (FargoSoulsGlobalProjectile.globalProjectileField is not null && FargoSoulsGlobalProjectile.ninjaCritIncrease > 0)
             {
                 if (FargoSoulsGlobalProjectile.globalProjectileField.CritChance - FargoSoulsGlobalProjectile.ninjaCritIncrease < 0)
@@ -506,6 +511,25 @@ namespace FargowiltasSouls
                 FargoSoulsGlobalProjectile.globalProjectileField = null;
             }
             return orig(self, hit, fromNet, noPlayerInteraction);
+        }
+
+        internal void NerfCoinGun(Orig_PickAmmo orig, Player self, Item sItem, ref int projToShoot, ref float speed, ref bool canShoot, ref int totalDamage, ref float KnockBack, out int usedAmmoItemId, bool dontConsume)
+        {
+            orig(self, sItem, ref projToShoot, ref speed, ref canShoot, ref totalDamage, ref KnockBack, out usedAmmoItemId, dontConsume);
+            if (self is not null)
+            {
+                if (canShoot && sItem.type == ItemID.CoinGun && projToShoot >= ProjectileID.CopperCoin && projToShoot <= ProjectileID.PlatinumCoin && EmodeItemBalance.HasEmodeChange(self, sItem.type))
+                {
+                    if (projToShoot == ProjectileID.CopperCoin)
+                        totalDamage = (int)(totalDamage * 1.6f);
+                    else if (projToShoot == ProjectileID.SilverCoin)
+                        totalDamage = (int)(totalDamage * 0.9f);
+                    else if (projToShoot == ProjectileID.GoldCoin)
+                        totalDamage = (int)(totalDamage * 0.47f);
+                    else if (projToShoot == ProjectileID.PlatinumCoin)
+                        totalDamage = (int)(totalDamage * 0.275f);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Replaced ModifyHitNPC tweaks with a highly specific detour to ensure the damage tweaks are done directly after damage from ammo is grabbed, making it more compatible with enchantments with values dependent on weapon base damage such as Boreal Wood