### PR TITLE
Fixes:

### DIFF
--- a/Content/Buffs/FargoGlobalBuff.cs
+++ b/Content/Buffs/FargoGlobalBuff.cs
@@ -1,5 +1,6 @@
 ﻿using FargowiltasSouls.Content.Buffs.Eternity;
 using FargowiltasSouls.Content.Buffs.Souls;
+using FargowiltasSouls.Content.Items;
 using FargowiltasSouls.Content.Items.Accessories.Enchantments;
 using FargowiltasSouls.Core.AccessoryEffectSystem;
 using FargowiltasSouls.Core.Globals;
@@ -24,13 +25,16 @@ namespace FargowiltasSouls.Content.Buffs
                 switch (type)
                 {
                     case BuffID.ShadowDodge:
-                        tip += "\n" + Language.GetTextValue("Mods.FargowiltasSouls.EModeBalance.ShadowDodge");
-                        break;
-                    case BuffID.IceBarrier:
-                        tip += "\n" + Language.GetTextValue("Mods.FargowiltasSouls.EModeBalance.IceBarrier");
+                        if (EmodeItemBalance.HasEmodeChange(Main.LocalPlayer, ItemID.HallowedPlateMail))
+                        {
+                            tip += "\n" + Language.GetTextValue("Mods.FargowiltasSouls.EModeBalance.ShadowDodge");
+                        }
                         break;
                     case BuffID.ChaosState:
-                        tip += "\n" + Language.GetTextValue("Mods.FargowiltasSouls.EModeBalance.RodofDiscord");
+                        if (EmodeItemBalance.HasEmodeChange(Main.LocalPlayer, ItemID.RodofDiscord))
+                        {
+                            tip += "\n" + Language.GetTextValue("Mods.FargowiltasSouls.EModeBalance.RodofDiscord");
+                        }
                         break;
                 }
             }

--- a/Core/ModPlayers/EModePlayer.cs
+++ b/Core/ModPlayers/EModePlayer.cs
@@ -150,7 +150,7 @@ namespace FargowiltasSouls.Core.ModPlayers
 
             Player.wellFed = true; //no longer expert half regen unless fed
 
-            if (Player.chaosState)
+            if (Player.chaosState && EmodeItemBalance.HasEmodeChange(Player, ItemID.RodofDiscord))
             {
                 Player.statDefense *= 0.6f;
                 Player.endurance -= 0.4f;


### PR DESCRIPTION
Chaos State EMode nerf and its debuff tooltip, and Holy Dodge EMode nerf tooltip now check whether the change has been disabled or not