### PR TITLE
EMode player stat buff tweaks:

### DIFF
--- a/Core/ModPlayers/EModePlayer.cs
+++ b/Core/ModPlayers/EModePlayer.cs
@@ -137,7 +137,7 @@ namespace FargowiltasSouls.Core.ModPlayers
             if (!WorldSavingSystem.EternityMode)
                 return;
 
-            Player.pickSpeed -= 0.25f;
+            //Player.pickSpeed -= 0.25f;
 
             Player.tileSpeed += 0.25f;
             Player.wallSpeed += 0.25f;

--- a/FargoSoulsSets.cs
+++ b/FargoSoulsSets.cs
@@ -2,6 +2,7 @@
 using FargowiltasSouls.Content.Items.Weapons.Challengers;
 using System.Collections.Generic;
 using System.Linq;
+using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 using static Terraria.ModLoader.ModContent;
@@ -21,6 +22,10 @@ namespace FargowiltasSouls
         public class NPCs
         {
 
+        }
+        public class Tiles
+        {
+            public static List<int> CommonTiles;
         }
 
         public override void PostSetupContent()
@@ -73,6 +78,51 @@ namespace FargowiltasSouls
             #endregion
             #region NPCs
             SetFactory npcFactory = NPCID.Sets.Factory;
+            #endregion
+            #region Tiles
+            //SetFactory tileFactory = TileID.Sets.Factory;
+
+            var Shovel = TileID.Sets.CanBeDugByShovel.GetTrueIndexes();
+            var Stone = TileID.Sets.Conversion.Stone.GetTrueIndexes();
+            var Sand = TileID.Sets.Conversion.Sand.GetTrueIndexes();
+            var Sandstone = TileID.Sets.Conversion.HardenedSand.GetTrueIndexes();
+            var Ice = TileID.Sets.Conversion.Ice.GetTrueIndexes();
+            var Mud = TileID.Sets.Mud.GetTrueIndexes();
+            Tiles.CommonTiles =
+            [
+                TileID.Marble,
+                TileID.Granite
+            ];
+            for (int i = 0; i < Shovel.Count; i++)
+            {
+                if (!Tiles.CommonTiles.Contains(Shovel[i]))
+                    Tiles.CommonTiles.Add(Shovel[i]);
+            }
+            for (int i = 0; i < Stone.Count; i++)
+            {
+                if (!Tiles.CommonTiles.Contains(Stone[i]))
+                    Tiles.CommonTiles.Add(Stone[i]);
+            }
+            for (int i = 0; i < Sand.Count; i++)
+            {
+                if (!Tiles.CommonTiles.Contains(Sand[i]))
+                    Tiles.CommonTiles.Add(Sand[i]);
+            }
+            for (int i = 0; i < Sandstone.Count; i++)
+            {
+                if (!Tiles.CommonTiles.Contains(Sandstone[i]))
+                    Tiles.CommonTiles.Add(Sandstone[i]);
+            }
+            for (int i = 0; i < Ice.Count; i++)
+            {
+                if (!Tiles.CommonTiles.Contains(Ice[i]))
+                    Tiles.CommonTiles.Add(Ice[i]);
+            }
+            for (int i = 0; i < Mud.Count; i++)
+            {
+                if (!Tiles.CommonTiles.Contains(Mud[i]))
+                    Tiles.CommonTiles.Add(Mud[i]);
+            }
             #endregion
         }
     }

--- a/FargowiltasSoulsDetours.cs
+++ b/FargowiltasSoulsDetours.cs
@@ -41,11 +41,15 @@ namespace FargowiltasSouls
 
         private static readonly MethodInfo? On_Player_PickAmmo_Method = typeof(Player).GetMethod("PickAmmo", BindingFlags.Instance | BindingFlags.NonPublic);
 
+        private static readonly MethodInfo? On_TileLoader_PickPowerCheck_Method = typeof(TileLoader).GetMethod("PickPowerCheck", LumUtils.UniversalBindingFlags);
+
         public delegate void Orig_CombinedHooks_ModifyHitNPCWithProj(Projectile projectile, NPC nPC, ref NPC.HitModifiers modifiers);
 
         public delegate int Orig_StrikeNPC_HitInfo_bool_bool(NPC nPC, NPC.HitInfo hit, bool fromNet, bool noPlayerInteraction);
 
         public delegate void Orig_PickAmmo(Player self, Item sItem, ref int projToShoot, ref float speed, ref bool canShoot, ref int totalDamage, ref float KnockBack, out int usedAmmoItemId, bool dontConsume);
+
+        public delegate void Orig_PickPowerCheck(Tile target, int pickPower, ref int damage);
 
         public void LoadDetours()
         {
@@ -138,6 +142,7 @@ namespace FargowiltasSouls
             HookHelper.ModifyMethodWithDetour(CombinedHooks_ModifyHitNPCWithProj_Method, CombinedHooks_ModifyHitNPCWithProj);
             HookHelper.ModifyMethodWithDetour(On_NPC_StrikeNPC_HitInfo_bool_bool_Method, UndoNinjaEnchCrit);
             HookHelper.ModifyMethodWithDetour(On_Player_PickAmmo_Method, NerfCoinGun);
+            HookHelper.ModifyMethodWithDetour(On_TileLoader_PickPowerCheck_Method, MakeCommonTilesEasierToBreak);
         }
 
         private static bool LifeRevitalizer_CheckSpawn_Internal(
@@ -572,6 +577,14 @@ namespace FargowiltasSouls
                     value = orig(self, damageSource, Damage, hitDirection, out info, pvp, true, cooldownCounter, false, armorPenetration, scalingArmorPenetration, 0f);
             }
             return value;
+        }
+        public static void MakeCommonTilesEasierToBreak(Orig_PickPowerCheck orig, Tile target, int pickPower, ref int damage)
+        {
+            if (WorldSavingSystem.EternityMode && FargoSoulsSets.Tiles.CommonTiles.Contains(target.TileType))
+            {
+                damage *= 2;
+            }
+            orig(target, pickPower, ref damage);
         }
     }
 }


### PR DESCRIPTION
No longer buffs mining speed
Now makes most common worldgen tiles easier to break