### PR TITLE
change ruminate tooltips to be crossmodable

### DIFF
--- a/Content/Items/FargoGlobalItem.cs
+++ b/Content/Items/FargoGlobalItem.cs
@@ -203,6 +203,7 @@ namespace FargowiltasSouls.Content.Items
             ModContent.ItemType<VerdantDoomsayerMask>(),
             ModContent.ItemType<HeartoftheMasochist>()
         ];
+        public static List<string> SoulsMods = ["FargowiltasSouls", "FargowiltasCrossmod", "FargowiltasSoulsDLC"];
 
         public override void ModifyItemScale(Item item, Player player, ref float scale)
         {
@@ -611,15 +612,15 @@ namespace FargowiltasSouls.Content.Items
                 }
             }
 
-            if (item.ModItem != null && item.ModItem.Mod == FargowiltasSouls.Instance)
+            if (item.ModItem != null && SoulsMods.Contains(item.ModItem.Mod.Name))
             {
-                string ruminateKey = $"Mods.FargowiltasSouls.Items.{item.ModItem.Name}.RuminateTooltip";
+                string ruminateKey = $"Mods.{item.ModItem.Mod.Name}.Items.{item.ModItem.Name}.RuminateTooltip";
                 string rumination = Language.GetTextValue(ruminateKey);
                 if (rumination != ruminateKey)
                 {
                     if (FargowiltasSouls.RuminateKey.Current)
                     {
-                        string unmodifiedTooltip = Language.GetTextValue($"Mods.FargowiltasSouls.Items.{item.ModItem.Name}.Tooltip");
+                        string unmodifiedTooltip = Language.GetTextValue($"Mods.{item.ModItem.Mod.Name}.Items.{item.ModItem.Name}.Tooltip");
                         foreach (var tooltip in tooltips)
                         {
                             if (tooltip.Name.StartsWith("Tooltip"))


### PR DESCRIPTION
tooltips now check for the mod the item is from, and added a list that mod developers can add their mod name to to give them access to the ruminate tooltip feature.