### PR TITLE
Fixed Menu Tick Playing On Difficulty Selector Dragging

### DIFF
--- a/Content/UI/Elements/UIOncomingMutant.cs
+++ b/Content/UI/Elements/UIOncomingMutant.cs
@@ -92,6 +92,7 @@ namespace FargowiltasSouls.Content.UI.Elements
             if (ContainsPoint(Main.MouseScreen) && conditions)
             {
                 if (!Hovering)
+                    if (!dragging)
                     SoundEngine.PlaySound(SoundID.MenuTick);
                 Hovering = true;
                 Main.LocalPlayer.mouseInterface = true;


### PR DESCRIPTION
Moving the difficulty selector icon too fast would constantly play the menu tick audio.