### PR TITLE
EMode+ Deerclops:

### DIFF
--- a/Content/Bosses/VanillaEternity/Deerclops.cs
+++ b/Content/Bosses/VanillaEternity/Deerclops.cs
@@ -141,8 +141,6 @@ namespace FargowiltasSouls.Content.Bosses.VanillaEternity
             if (Main.LocalPlayer.active && !Main.LocalPlayer.ghost && !Main.LocalPlayer.dead && npc.Distance(Main.LocalPlayer.Center) < 1000)
             {
                 Main.LocalPlayer.AddBuff(ModContent.BuffType<LowGroundBuff>(), 2);
-                Main.LocalPlayer.buffImmune[BuffID.Frozen] = true;
-                Main.LocalPlayer.buffImmune[BuffID.Slow] = true;
             }
             if (npc.ai[0] != 1)
                 HandsCheck = true;

--- a/FargowiltasSouls.cs
+++ b/FargowiltasSouls.cs
@@ -100,6 +100,8 @@ namespace FargowiltasSouls
 
         public UserInterface CustomResources;
 
+        private NPC DeerclopsAICurrentlyRunning;
+
         internal static Dictionary<int, int> ModProjDict = [];
 
         public static bool DrawingTooltips = false;

--- a/Localization/es-ES/Mods.FargowiltasSouls.Items.hjson
+++ b/Localization/es-ES/Mods.FargowiltasSouls.Items.hjson
@@ -106,10 +106,8 @@ CactusEnchant: {
 		'''
 		While attacking you release a spray of needles in every direction
 		Enemies hit by needles will spray more needles on death
-		Passive cactuses become harmless (works from inventory or vanity slots)
 		'It's the quenchiest!'
 		''' */
-	// VanityTooltip: Passive cactuses become harmless
 }
 
 ChlorophyteEnchant: {
@@ -826,10 +824,8 @@ LifeForce: {
 		[i:FargowiltasSouls/BeetleEnchant] The Ambrosia buff provides +20% damage, +8% damage reduction, and 5 life regeneration
 		[i:FargowiltasSouls/TurtleEnchant] Hover in place with the wings to enter a shell and resist damage for one hit
 		[i:FargowiltasSouls/BeeEnchant] Effects of Hive Pack
-		[i:FargowiltasSouls/CactusEnchant] Passive cactuses become harmless (works from inventory or vanity slots)
 		'Rare is a living thing that dare disobey your will'
 		''' */
-	// VanityTooltip: Passive cactuses become harmless
 }
 
 NatureForce: {


### PR DESCRIPTION
Replaced giving player immunity to the bad vanilla debuffs with detours that make them not inflicted in the first place