### PR TITLE
Fixed incorrect npc/proj immunity cooldown slots:

### DIFF
--- a/Content/Bosses/AbomBoss/AbomRitualFTW.cs
+++ b/Content/Bosses/AbomBoss/AbomRitualFTW.cs
@@ -29,7 +29,7 @@ namespace FargowiltasSouls.Content.Bosses.AbomBoss
         public override void SetDefaults()
         {
             base.SetDefaults();
-            CooldownSlot = 0;
+            CooldownSlot = ImmunityCooldownID.TileContactDamage;
         }
         protected override void Movement(NPC npc)
         {

--- a/Content/Bosses/Champions/Will/WillFireball.cs
+++ b/Content/Bosses/Champions/Will/WillFireball.cs
@@ -41,7 +41,7 @@ namespace FargowiltasSouls.Content.Bosses.Champions.Will
         {
             base.OnSpawn(source);
             if (source is EntitySource_Parent parent && parent.Entity is NPC sourceNPC && sourceNPC.type is NPCID.DD2Betsy)
-                CooldownSlot = -1;
+                CooldownSlot = ImmunityCooldownID.General;
         }
         public override void AI()
         {

--- a/Content/Bosses/MutantBoss/MutantEyeWavy.cs
+++ b/Content/Bosses/MutantBoss/MutantEyeWavy.cs
@@ -25,7 +25,7 @@ namespace FargowiltasSouls.Content.Bosses.MutantBoss
             base.SetDefaults();
             Projectile.timeLeft = 180;
             Projectile.FargoSouls().TimeFreezeImmune = true;
-            CooldownSlot = 0;
+            CooldownSlot = ImmunityCooldownID.TileContactDamage;
         }
 
         private float Amplitude => Projectile.ai[0];

--- a/Content/Bosses/MutantBoss/MutantFishronRitual.cs
+++ b/Content/Bosses/MutantBoss/MutantFishronRitual.cs
@@ -5,6 +5,7 @@ using FargowiltasSouls.Core.Systems;
 using Microsoft.Xna.Framework;
 using System;
 using Terraria;
+using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace FargowiltasSouls.Content.Bosses.MutantBoss
@@ -24,7 +25,7 @@ namespace FargowiltasSouls.Content.Bosses.MutantBoss
             Projectile.timeLeft = 600;
             Projectile.alpha = 255;
             Projectile.penetrate = -1;
-            CooldownSlot = -1;
+            CooldownSlot = ImmunityCooldownID.Bosses;
 
             Projectile.FargoSouls().GrazeCheck =
                 projectile =>

--- a/Content/Bosses/MutantBoss/MutantSpikevine.cs
+++ b/Content/Bosses/MutantBoss/MutantSpikevine.cs
@@ -45,6 +45,7 @@ namespace FargowiltasSouls.Content.Projectiles.Eternity.Bosses.Plantera
             Projectile.scale = 1;
             Projectile.Opacity = 0;
             Projectile.hide = true;
+            CooldownSlot = ImmunityCooldownID.Bosses;
         }
         ref float Timer => ref Projectile.ai[0];
         ref float MutantID => ref Projectile.ai[1];

--- a/Content/Bosses/TrojanSquirrel/TrojanAcorn.cs
+++ b/Content/Bosses/TrojanSquirrel/TrojanAcorn.cs
@@ -19,7 +19,7 @@ namespace FargowiltasSouls.Content.Bosses.TrojanSquirrel
             base.SetDefaults();
 
             Projectile.tileCollide = true;
-            CooldownSlot = -1;
+            CooldownSlot = ImmunityCooldownID.General;
         }
 
         public override void OnKill(int timeLeft)

--- a/Content/Bosses/VanillaEternity/LunaticCultist.cs
+++ b/Content/Bosses/VanillaEternity/LunaticCultist.cs
@@ -905,6 +905,9 @@ namespace FargowiltasSouls.Content.Bosses.VanillaEternity
 
         public override bool CanHitPlayer(NPC npc, Player target, ref int CooldownSlot)
         {
+            if (!WorldSavingSystem.EternityMode)
+                return base.CanHitPlayer(npc, target, ref CooldownSlot);
+            CooldownSlot = ImmunityCooldownID.Bosses;
             return base.CanHitPlayer(npc, target, ref CooldownSlot) && npc.localAI[3] > 120;
         }
 
@@ -1045,7 +1048,7 @@ namespace FargowiltasSouls.Content.Bosses.VanillaEternity
             if (!WorldSavingSystem.EternityMode)
                 return base.CanHitPlayer(npc, target, ref cooldownSlot);
 
-            if (SourceNPCType is NPCID.MoonLordCore or NPCID.MoonLordHead or NPCID.MoonLordHand)
+            if (SourceNPCType is NPCID.CultistBoss or NPCID.CultistBossClone or NPCID.MoonLordCore or NPCID.MoonLordHead or NPCID.MoonLordHand)
                 cooldownSlot = ImmunityCooldownID.Bosses;
 
             return base.CanHitPlayer(npc, target, ref cooldownSlot);

--- a/Content/Patreon/Duck/RailgunBlast.cs
+++ b/Content/Patreon/Duck/RailgunBlast.cs
@@ -17,7 +17,7 @@ namespace FargowiltasSouls.Content.Patreon.Duck
         {
             base.SetDefaults();
 
-            CooldownSlot = -1;
+            CooldownSlot = ImmunityCooldownID.General;
             Projectile.hostile = false;
             Projectile.friendly = true;
             Projectile.DamageType = DamageClass.Ranged;

--- a/Content/Projectiles/Accessories/Souls/VortexLaser.cs
+++ b/Content/Projectiles/Accessories/Souls/VortexLaser.cs
@@ -23,7 +23,7 @@ namespace FargowiltasSouls.Content.Projectiles.Accessories.Souls
         public override void SetDefaults()
         {
             base.SetDefaults();
-            CooldownSlot = -1;
+            CooldownSlot = ImmunityCooldownID.General;
             Projectile.hostile = false;
             Projectile.friendly = true;
             Projectile.DamageType = DamageClass.Ranged;

--- a/Content/Projectiles/Deathrays/GolemBeam.cs
+++ b/Content/Projectiles/Deathrays/GolemBeam.cs
@@ -28,7 +28,7 @@ namespace FargowiltasSouls.Content.Projectiles.Deathrays
         public override void SetDefaults()
         {
             base.SetDefaults();
-            CooldownSlot = -1;
+            CooldownSlot = ImmunityCooldownID.General;
         }
         public override void AI()
         {

--- a/Content/Projectiles/Eternity/Bosses/DukeFishron/FishronFishron.cs
+++ b/Content/Projectiles/Eternity/Bosses/DukeFishron/FishronFishron.cs
@@ -24,7 +24,7 @@ namespace FargowiltasSouls.Content.Projectiles.Eternity.Bosses.DukeFishron
         {
             base.SetDefaults();
             Projectile.width = Projectile.height = 40;
-            CooldownSlot = -1;
+            CooldownSlot = ImmunityCooldownID.General;
         }
 
         public override bool? Colliding(Rectangle projHitbox, Rectangle targetHitbox)

--- a/Content/Projectiles/Eternity/Bosses/DukeFishron/FishronRitual2.cs
+++ b/Content/Projectiles/Eternity/Bosses/DukeFishron/FishronRitual2.cs
@@ -18,13 +18,13 @@ namespace FargowiltasSouls.Content.Projectiles.Eternity.Bosses.DukeFishron
 
             // DisplayName.SetDefault("Oceanic Ritual");
             Main.projFrames[Projectile.type] = 3;
-            CooldownSlot = 0;
+            CooldownSlot = ImmunityCooldownID.TileContactDamage;
         }
 
         public override void SetDefaults()
         {
             base.SetDefaults();
-            CooldownSlot = 0;
+            CooldownSlot = ImmunityCooldownID.TileContactDamage;
         }
         protected override void Movement(NPC npc)
         {

--- a/Content/Projectiles/Eternity/Bosses/EyeOfCthulhu/BloodScythe.cs
+++ b/Content/Projectiles/Eternity/Bosses/EyeOfCthulhu/BloodScythe.cs
@@ -36,7 +36,7 @@ namespace FargowiltasSouls.Content.Projectiles.Eternity.Bosses.EyeOfCthulhu
             Projectile.DamageType = DamageClass.Generic;
             Projectile.timeLeft = 300;
             Projectile.tileCollide = false;
-            CooldownSlot = -1;
+            CooldownSlot = ImmunityCooldownID.General;
 
             randomize = 0;
         }

--- a/Content/Projectiles/Eternity/Bosses/MechanicalBosses/PrimeGuardian.cs
+++ b/Content/Projectiles/Eternity/Bosses/MechanicalBosses/PrimeGuardian.cs
@@ -24,7 +24,7 @@ namespace FargowiltasSouls.Content.Projectiles.Eternity.Bosses.MechanicalBosses
         {
             base.SetDefaults();
             Projectile.timeLeft = 600;
-            CooldownSlot = -1;
+            CooldownSlot = ImmunityCooldownID.General;
         }
 
         public override bool CanHitPlayer(Player target)

--- a/Content/Projectiles/Eternity/Bosses/MoonLord/MoonLordSunBlast.cs
+++ b/Content/Projectiles/Eternity/Bosses/MoonLord/MoonLordSunBlast.cs
@@ -40,7 +40,7 @@ namespace FargowiltasSouls.Content.Projectiles.Eternity
                 && (npc.type == NPCID.GolemFistLeft || npc.type == NPCID.GolemFistRight))
             {
                 Projectile.localAI[2] = 1;
-                CooldownSlot = -1;
+                CooldownSlot = ImmunityCooldownID.General;
             }
         }
 

--- a/Content/Projectiles/Eternity/Bosses/Plantera/PlanteraCrystalLeafRing.cs
+++ b/Content/Projectiles/Eternity/Bosses/Plantera/PlanteraCrystalLeafRing.cs
@@ -22,7 +22,7 @@ namespace FargowiltasSouls.Content.Projectiles.Eternity
         {
             base.SetDefaults();
             Projectile.scale = 1.5f;
-            CooldownSlot = -1;
+            CooldownSlot = ImmunityCooldownID.General;
             Projectile.FargoSouls().DeletionImmuneRank = 1;
         }
 

--- a/Content/Projectiles/Eternity/Enemies/CultistArrow.cs
+++ b/Content/Projectiles/Eternity/Enemies/CultistArrow.cs
@@ -21,7 +21,7 @@ namespace FargowiltasSouls.Content.Projectiles.Eternity.Enemies
             Projectile.CloneDefaults(ProjectileID.WoodenArrowHostile);
             AIType = ProjectileID.WoodenArrowHostile;
             Projectile.extraUpdates = 1;
-            CooldownSlot = ImmunityCooldownID.Bosses;
+            //CooldownSlot = ImmunityCooldownID.Bosses;
         }
 
         public override void OnHitPlayer(Player target, Player.HurtInfo info)

--- a/Content/Projectiles/Eternity/Enemies/Vanilla/BloodMoon/ClownBomb.cs
+++ b/Content/Projectiles/Eternity/Enemies/Vanilla/BloodMoon/ClownBomb.cs
@@ -22,7 +22,7 @@ namespace FargowiltasSouls.Content.Projectiles.Eternity.Enemies.Vanilla.BloodMoo
 
             Projectile.timeLeft = 300;
             Projectile.tileCollide = true;
-            CooldownSlot = ImmunityCooldownID.Bosses;
+            //CooldownSlot = ImmunityCooldownID.Bosses;
         }
 
         public override Color? GetAlpha(Color lightColor)

--- a/Content/Projectiles/Eternity/Enemies/Vanilla/BloodMoon/FusedExplosion.cs
+++ b/Content/Projectiles/Eternity/Enemies/Vanilla/BloodMoon/FusedExplosion.cs
@@ -17,7 +17,7 @@ namespace FargowiltasSouls.Content.Projectiles.Eternity.Enemies.Vanilla.BloodMoo
             Projectile.friendly = true;
             Projectile.hostile = true;
             Projectile.trap = true;
-            CooldownSlot = -1;
+            CooldownSlot = ImmunityCooldownID.General;
         }
 
         public override void ModifyHitPlayer(Player target, ref Player.HurtModifiers modifiers)

--- a/Content/Projectiles/Eternity/Enemies/Vanilla/Cavern/FakeHeart.cs
+++ b/Content/Projectiles/Eternity/Enemies/Vanilla/Cavern/FakeHeart.cs
@@ -6,6 +6,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.DataStructures;
+using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
 
@@ -22,7 +23,7 @@ namespace FargowiltasSouls.Content.Projectiles.Eternity.Enemies.Vanilla.Cavern
             Projectile.timeLeft = 600;
             Projectile.hostile = true;
             Projectile.aiStyle = -1;
-            CooldownSlot = 0;
+            CooldownSlot = ImmunityCooldownID.TileContactDamage;
         }
 
         public override void AI()

--- a/Content/Projectiles/Eternity/Enemies/Vanilla/Cavern/MimicDagger.cs
+++ b/Content/Projectiles/Eternity/Enemies/Vanilla/Cavern/MimicDagger.cs
@@ -24,7 +24,7 @@ namespace FargowiltasSouls.Content.Projectiles.Eternity.Enemies.Vanilla.Cavern
             Projectile.DamageType = DamageClass.Generic;
             Projectile.timeLeft = 300;
             Projectile.tileCollide = false;
-            CooldownSlot = ImmunityCooldownID.Bosses;
+            //CooldownSlot = ImmunityCooldownID.Bosses;
         }
 
         public override void AI()

--- a/Content/Projectiles/Eternity/Enemies/Vanilla/Cavern/MimicHallowStar.cs
+++ b/Content/Projectiles/Eternity/Enemies/Vanilla/Cavern/MimicHallowStar.cs
@@ -21,7 +21,7 @@ namespace FargowiltasSouls.Content.Projectiles.Eternity.Enemies.Vanilla.Cavern
             Projectile.timeLeft = 300;
             Projectile.tileCollide = false;
             Projectile.light = 1f;
-            CooldownSlot = ImmunityCooldownID.Bosses;
+            //CooldownSlot = ImmunityCooldownID.Bosses;
         }
 
         public override void PostAI()

--- a/Content/Projectiles/Eternity/Enemies/Vanilla/Cavern/MimicTitanGlove.cs
+++ b/Content/Projectiles/Eternity/Enemies/Vanilla/Cavern/MimicTitanGlove.cs
@@ -24,7 +24,7 @@ namespace FargowiltasSouls.Content.Projectiles.Eternity.Enemies.Vanilla.Cavern
             Projectile.DamageType = DamageClass.Generic;
             Projectile.timeLeft = 300;
             Projectile.tileCollide = false;
-            CooldownSlot = ImmunityCooldownID.Bosses;
+            //CooldownSlot = ImmunityCooldownID.Bosses;
         }
 
         public override void AI()

--- a/Content/Projectiles/Eternity/Enemies/Vanilla/Desert/VultureFeather.cs
+++ b/Content/Projectiles/Eternity/Enemies/Vanilla/Desert/VultureFeather.cs
@@ -17,7 +17,7 @@ namespace FargowiltasSouls.Content.Projectiles.Eternity.Enemies.Vanilla.Desert
             Projectile.friendly = false;
             Projectile.timeLeft = 600;
             Projectile.tileCollide = true;
-            CooldownSlot = ImmunityCooldownID.Bosses; // do we need this?
+            //CooldownSlot = ImmunityCooldownID.Bosses; // do we need this? (we don't)
         }
 
         public override void OnKill(int timeLeft)

--- a/Content/Projectiles/Eternity/Enemies/Vanilla/PumpkinMoon/PumpkingFlamingScythe.cs
+++ b/Content/Projectiles/Eternity/Enemies/Vanilla/PumpkinMoon/PumpkingFlamingScythe.cs
@@ -42,7 +42,7 @@ namespace FargowiltasSouls.Content.Projectiles.Eternity.Enemies.Vanilla.PumpkinM
 
             if (FargoSoulsUtil.BossIsAlive(ref EModeGlobalNPC.abomBoss, ModContent.NPCType<AbomBoss>()))
             {
-                CooldownSlot = 1;
+                CooldownSlot = ImmunityCooldownID.Bosses;
                 renderTrail = true;
             }
         }

--- a/Content/Projectiles/Eternity/Enemies/Vanilla/SolarEclipse/MothronZenith.cs
+++ b/Content/Projectiles/Eternity/Enemies/Vanilla/SolarEclipse/MothronZenith.cs
@@ -33,7 +33,7 @@ namespace FargowiltasSouls.Content.Projectiles.Eternity.Enemies.Vanilla.SolarEcl
 
             Projectile.hide = true;
 
-            CooldownSlot = ImmunityCooldownID.Bosses;
+            //CooldownSlot = ImmunityCooldownID.Bosses;
         }
 
         public override bool? CanDamage()

--- a/Content/Projectiles/GiantDeathray.cs
+++ b/Content/Projectiles/GiantDeathray.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using Terraria;
 using Terraria.Audio;
+using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace FargowiltasSouls.Content.Projectiles
@@ -31,7 +32,7 @@ namespace FargowiltasSouls.Content.Projectiles
             Projectile.FargoSouls().CanSplit = false;
 
             Projectile.hide = true;
-            CooldownSlot = -1;
+            CooldownSlot = ImmunityCooldownID.General;
         }
 
         public override void DrawBehind(int index, List<int> behindNPCsAndTiles, List<int> behindNPCs, List<int> behindProjectiles, List<int> overPlayers, List<int> overWiresUI)

--- a/Content/Projectiles/Weapons/BossWeapons/ElectricWhipLightning.cs
+++ b/Content/Projectiles/Weapons/BossWeapons/ElectricWhipLightning.cs
@@ -27,7 +27,7 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.BossWeapons
         public override void SetDefaults()
         {
             base.SetDefaults();
-            CooldownSlot = -1;
+            CooldownSlot = ImmunityCooldownID.General;
             Projectile.hostile = false;
             Projectile.friendly = true;
             Projectile.DamageType = DamageClass.SummonMeleeSpeed;

--- a/Content/Projectiles/Weapons/BossWeapons/SlimeRainBall.cs
+++ b/Content/Projectiles/Weapons/BossWeapons/SlimeRainBall.cs
@@ -17,7 +17,7 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.BossWeapons
             Projectile.friendly = true;
             Projectile.DamageType = DamageClass.Melee;
             Projectile.penetrate = 1;
-            CooldownSlot = -1;
+            CooldownSlot = ImmunityCooldownID.General;
         }
 
         public override void AI()

--- a/Content/Projectiles/Weapons/FinalUpgrades/PenetratorBigDeathray.cs
+++ b/Content/Projectiles/Weapons/FinalUpgrades/PenetratorBigDeathray.cs
@@ -20,7 +20,7 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.FinalUpgrades
         public override void SetDefaults()
         {
             base.SetDefaults();
-            CooldownSlot = -1;
+            CooldownSlot = ImmunityCooldownID.General;
             Projectile.hostile = false;
             Projectile.friendly = true;
             Projectile.DamageType = DamageClass.Ranged;

--- a/Content/Projectiles/Weapons/FinalUpgrades/PenetratorDeathray.cs
+++ b/Content/Projectiles/Weapons/FinalUpgrades/PenetratorDeathray.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Terraria;
 using Terraria.Audio;
+using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace FargowiltasSouls.Content.Projectiles.Weapons.FinalUpgrades
@@ -23,7 +24,7 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.FinalUpgrades
         public override void SetDefaults()
         {
             base.SetDefaults();
-            CooldownSlot = -1;
+            CooldownSlot = ImmunityCooldownID.General;
             Projectile.hostile = false;
             Projectile.friendly = true;
             Projectile.DamageType = DamageClass.Melee;

--- a/Content/Projectiles/Weapons/FinalUpgrades/PenetratorDeathray2.cs
+++ b/Content/Projectiles/Weapons/FinalUpgrades/PenetratorDeathray2.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Terraria;
 using Terraria.Audio;
+using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace FargowiltasSouls.Content.Projectiles.Weapons.FinalUpgrades
@@ -23,7 +24,7 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.FinalUpgrades
         public override void SetDefaults()
         {
             base.SetDefaults();
-            CooldownSlot = -1;
+            CooldownSlot = ImmunityCooldownID.General;
             Projectile.hostile = false;
             Projectile.friendly = true;
             Projectile.DamageType = DamageClass.Melee;

--- a/Content/Projectiles/Weapons/Minions/AbomMinionScythe.cs
+++ b/Content/Projectiles/Weapons/Minions/AbomMinionScythe.cs
@@ -35,7 +35,7 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.Minions
             Projectile.usesLocalNPCImmunity = true;
             Projectile.localNPCHitCooldown = 10;
 
-            CooldownSlot = -1;
+            CooldownSlot = ImmunityCooldownID.General;
         }
 
         public override void AI()

--- a/Content/Projectiles/Weapons/Minions/AbomMinionSickle.cs
+++ b/Content/Projectiles/Weapons/Minions/AbomMinionSickle.cs
@@ -31,7 +31,7 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.Minions
             Projectile.idStaticNPCHitCooldown = 5;
             Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
 
-            CooldownSlot = -1;
+            CooldownSlot = ImmunityCooldownID.General;
         }
 
         public override void OnHitPlayer(Player target, Player.HurtInfo info) { }

--- a/Content/Projectiles/Weapons/Minions/RingDeathray.cs
+++ b/Content/Projectiles/Weapons/Minions/RingDeathray.cs
@@ -29,7 +29,7 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.Minions
             Projectile.friendly = true;
             Projectile.hostile = false;
             Projectile.DamageType = DamageClass.Summon;
-            CooldownSlot = -1;
+            CooldownSlot = ImmunityCooldownID.General;
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 10;

--- a/Content/Projectiles/Weapons/SwarmDrops/PrimeDeathray.cs
+++ b/Content/Projectiles/Weapons/SwarmDrops/PrimeDeathray.cs
@@ -19,7 +19,7 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.SwarmDrops
         public override void SetDefaults()
         {
             base.SetDefaults();
-            CooldownSlot = -1;
+            CooldownSlot = ImmunityCooldownID.General;
             Projectile.hostile = false;
             Projectile.friendly = true;
             Projectile.DamageType = DamageClass.Magic;

--- a/Content/Projectiles/Weapons/SwarmDrops/RetiDeathray.cs
+++ b/Content/Projectiles/Weapons/SwarmDrops/RetiDeathray.cs
@@ -20,7 +20,7 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.SwarmDrops
         public override void SetDefaults()
         {
             base.SetDefaults();
-            CooldownSlot = -1;
+            CooldownSlot = ImmunityCooldownID.General;
             Projectile.hostile = false;
             Projectile.friendly = true;
             Projectile.DamageType = DamageClass.Melee;


### PR DESCRIPTION
Lunatic Cultist's Ancient Light and Ancient Doom
White Cultist Archer's Arrows
Clown Bomb
All regular Mimic projectiles
Vulture Feather
Mothron Zenith projectile
Mutant Fishron Ritual
Mutant Spike Vine
Associated numerous others with their ID names for readability