### PR TITLE
noInteractionWithNPCImmunityFrames:

### DIFF
--- a/Content/Patreon/Catsounds/KingSlimeBallPiercing.cs
+++ b/Content/Patreon/Catsounds/KingSlimeBallPiercing.cs
@@ -23,7 +23,6 @@ namespace FargowiltasSouls.Content.Patreon.Catsounds
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
     }
 }

--- a/Content/Patreon/Catsounds/KingSlimeSpike.cs
+++ b/Content/Patreon/Catsounds/KingSlimeSpike.cs
@@ -21,7 +21,6 @@ namespace FargowiltasSouls.Content.Patreon.Catsounds
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
     }
 }

--- a/Content/Patreon/Duck/RailgunBlast.cs
+++ b/Content/Patreon/Duck/RailgunBlast.cs
@@ -29,7 +29,6 @@ namespace FargowiltasSouls.Content.Patreon.Duck
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 12;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override bool? Colliding(Rectangle projHitbox, Rectangle targetHitbox)

--- a/Content/Patreon/GreatestKraken/VortexBolt.cs
+++ b/Content/Patreon/GreatestKraken/VortexBolt.cs
@@ -21,7 +21,6 @@ namespace FargowiltasSouls.Content.Patreon.GreatestKraken
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
 
             Projectile.timeLeft = 30 * (Projectile.extraUpdates + 1);
         }

--- a/Content/Patreon/GreatestKraken/VortexRitualProj.cs
+++ b/Content/Patreon/GreatestKraken/VortexRitualProj.cs
@@ -44,7 +44,6 @@ namespace FargowiltasSouls.Content.Patreon.GreatestKraken
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override bool? Colliding(Rectangle projHitbox, Rectangle targetHitbox)

--- a/Content/Patreon/Sasha/Bubble.cs
+++ b/Content/Patreon/Sasha/Bubble.cs
@@ -24,7 +24,6 @@ namespace FargowiltasSouls.Content.Patreon.Sasha
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 7;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
       /*public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)

--- a/Content/Patreon/Sasha/PufferRang.cs
+++ b/Content/Patreon/Sasha/PufferRang.cs
@@ -33,7 +33,6 @@ namespace FargowiltasSouls.Content.Patreon.Sasha
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 7;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Patreon/Sasha/PufferSpray.cs
+++ b/Content/Patreon/Sasha/PufferSpray.cs
@@ -29,7 +29,6 @@ namespace FargowiltasSouls.Content.Patreon.Sasha
 
             Projectile.usesLocalNPCImmunity = true;
             Projectile.localNPCHitCooldown = -1;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Patreon/Tiger/MystiaNote.cs
+++ b/Content/Patreon/Tiger/MystiaNote.cs
@@ -28,7 +28,6 @@ namespace FargowiltasSouls.Content.Patreon.Tiger
             Projectile.tileCollide = false;
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 20;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Patreon/Tiger/MystiaNote2.cs
+++ b/Content/Patreon/Tiger/MystiaNote2.cs
@@ -29,7 +29,6 @@ namespace FargowiltasSouls.Content.Patreon.Tiger
             Projectile.scale = 0.8f;
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 20;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Patreon/Tiger/RumiaOrb.cs
+++ b/Content/Patreon/Tiger/RumiaOrb.cs
@@ -26,7 +26,6 @@ namespace FargowiltasSouls.Content.Patreon.Tiger
             Projectile.scale = 0.5f;
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 20;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Projectiles/Accessories/BionomicCluster/ShadowflameTentacle.cs
+++ b/Content/Projectiles/Accessories/BionomicCluster/ShadowflameTentacle.cs
@@ -27,7 +27,6 @@ namespace FargowiltasSouls.Content.Projectiles.Accessories.BionomicCluster
             Projectile.penetrate = 2;
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)

--- a/Content/Projectiles/Accessories/HeartOfTheMaster/BetsyDash.cs
+++ b/Content/Projectiles/Accessories/HeartOfTheMaster/BetsyDash.cs
@@ -37,7 +37,6 @@ namespace FargowiltasSouls.Content.Projectiles.Accessories.HeartOfTheMaster
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 30;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Projectiles/Accessories/Souls/CactusNeedle.cs
+++ b/Content/Projectiles/Accessories/Souls/CactusNeedle.cs
@@ -28,7 +28,6 @@ namespace FargowiltasSouls.Content.Projectiles.Accessories.Souls
             Projectile.penetrate = 2; //dies on hit
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Projectiles/Accessories/Souls/CopperLightning.cs
+++ b/Content/Projectiles/Accessories/Souls/CopperLightning.cs
@@ -45,7 +45,6 @@ namespace FargowiltasSouls.Content.Projectiles.Accessories.Souls
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 180;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
         public override void AI()
         {

--- a/Content/Projectiles/Accessories/Souls/GladiatorJavelin.cs
+++ b/Content/Projectiles/Accessories/Souls/GladiatorJavelin.cs
@@ -27,7 +27,6 @@ namespace FargowiltasSouls.Content.Projectiles.Accessories.Souls
             Projectile.tileCollide = false;
             Projectile.extraUpdates = 1;
             Projectile.penetrate = 1;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
             
             FargowiltasSouls.MutantMod.Call("LowRenderProj", Projectile);
         }

--- a/Content/Projectiles/Accessories/Souls/MegaFlameburst.cs
+++ b/Content/Projectiles/Accessories/Souls/MegaFlameburst.cs
@@ -28,7 +28,6 @@ namespace FargowiltasSouls.Content.Projectiles.Accessories.Souls
 
             Projectile.usesLocalNPCImmunity = true;
             Projectile.localNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Projectiles/Accessories/Souls/ShroomiteShroom.cs
+++ b/Content/Projectiles/Accessories/Souls/ShroomiteShroom.cs
@@ -24,7 +24,6 @@ namespace FargowiltasSouls.Content.Projectiles.Accessories.Souls
             Projectile.DamageType = DamageClass.Ranged;
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 20;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
             Projectile.penetrate = 4;
             Projectile.ArmorPenetration = 20;
         }

--- a/Content/Projectiles/Accessories/SupremeDeathbringerFairy/BloodScytheFriendly.cs
+++ b/Content/Projectiles/Accessories/SupremeDeathbringerFairy/BloodScytheFriendly.cs
@@ -36,7 +36,6 @@ namespace FargowiltasSouls.Content.Projectiles.Accessories.SupremeDeathbringerFa
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 10;
             Projectile.FargoSouls().CanSplit = false;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
 
             FargowiltasSouls.MutantMod.Call("LowRenderProj", Projectile);
 

--- a/Content/Projectiles/Accessories/VerdantDoomsayerMask/CelestialRuneAncientVision.cs
+++ b/Content/Projectiles/Accessories/VerdantDoomsayerMask/CelestialRuneAncientVision.cs
@@ -29,7 +29,6 @@ namespace FargowiltasSouls.Content.Projectiles.Accessories.VerdantDoomsayerMask
             Projectile.timeLeft = 180;
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 20;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Projectiles/Accessories/VerdantDoomsayerMask/CelestialRuneLightningArc.cs
+++ b/Content/Projectiles/Accessories/VerdantDoomsayerMask/CelestialRuneLightningArc.cs
@@ -39,7 +39,6 @@ namespace FargowiltasSouls.Content.Projectiles.Accessories.VerdantDoomsayerMask
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
 
             FargowiltasSouls.MutantMod.Call("LowRenderProj", Projectile);
         }

--- a/Content/Projectiles/Accessories/VerdantDoomsayerMask/LihzahrdBoulderFriendly.cs
+++ b/Content/Projectiles/Accessories/VerdantDoomsayerMask/LihzahrdBoulderFriendly.cs
@@ -32,7 +32,6 @@ namespace FargowiltasSouls.Content.Projectiles.Accessories.VerdantDoomsayerMask
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 20;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
 
             FargowiltasSouls.MutantMod.Call("LowRenderProj", Projectile);
 

--- a/Content/Projectiles/EModeGlobalProjectile.cs
+++ b/Content/Projectiles/EModeGlobalProjectile.cs
@@ -232,7 +232,7 @@ namespace FargowiltasSouls.Content.Projectiles
 
             Projectile? sourceProj = null;
 
-            if (projectile is not null && projectile.owner.IsWithinBounds(Main.maxPlayers) && (projectile.friendly || FargoSoulsUtil.IsSummonDamage(projectile, false, false)))
+            if (projectile.owner.IsWithinBounds(Main.maxPlayers) && (projectile.friendly || FargoSoulsUtil.IsSummonDamage(projectile, false, false)))
             {
                 if (source is not null)
                 {
@@ -386,8 +386,6 @@ namespace FargowiltasSouls.Content.Projectiles
                             projectile.idStaticNPCHitCooldown = 3;
                         else
                             projectile.idStaticNPCHitCooldown = 5;
-
-                        projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
                     }
                     break;
 

--- a/Content/Projectiles/Explosion.cs
+++ b/Content/Projectiles/Explosion.cs
@@ -32,7 +32,6 @@ namespace FargowiltasSouls.Content.Projectiles
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
 
             Projectile.FargoSouls().DeletionImmuneRank = 2;
         }

--- a/Content/Projectiles/FargoSoulsGlobalProjectile.cs
+++ b/Content/Projectiles/FargoSoulsGlobalProjectile.cs
@@ -386,7 +386,6 @@ namespace FargowiltasSouls.Content.Projectiles
 
                             projectile.usesIDStaticNPCImmunity = true;
                             projectile.idStaticNPCHitCooldown = 10;
-                            noInteractionWithNPCImmunityFrames = true;
                         }
                     }
                     break;
@@ -409,7 +408,6 @@ namespace FargowiltasSouls.Content.Projectiles
                             projectile.idStaticNPCHitCooldown = 10;
 
                             projectile.FargoSouls().CanSplit = false;
-                            projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
 
                             FargowiltasSouls.MutantMod.Call("LowRenderProj", projectile);
                         }
@@ -508,6 +506,11 @@ namespace FargowiltasSouls.Content.Projectiles
                 {
                     ApprenticeSupportProjectile = true; // tag it, meaning we now know that this projectile is from Apprentice Support effect
                 }
+            }
+            if (projectile is not null && projectile.owner.IsWithinBounds(Main.maxPlayers) && projectile.friendly && !projectile.appliesImmunityTimeOnSingleHits &&
+               (projectile.penetrate > 1 || projectile.penetrate == -1) && (projectile.usesLocalNPCImmunity || projectile.usesIDStaticNPCImmunity))
+            {
+                noInteractionWithNPCImmunityFrames = true;
             }
         }
 

--- a/Content/Projectiles/GiantDeathray.cs
+++ b/Content/Projectiles/GiantDeathray.cs
@@ -27,7 +27,6 @@ namespace FargowiltasSouls.Content.Projectiles
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 0;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
             Projectile.FargoSouls().DeletionImmuneRank = 2;
             Projectile.FargoSouls().CanSplit = false;
 

--- a/Content/Projectiles/JungleMimic/JungleMimicSummon.cs
+++ b/Content/Projectiles/JungleMimic/JungleMimicSummon.cs
@@ -40,7 +40,6 @@ namespace FargowiltasSouls.Content.Projectiles.JungleMimic
             AIType = ProjectileID.BabySlime;
             Projectile.usesLocalNPCImmunity = true;
             Projectile.localNPCHitCooldown = 15;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
         public override bool? CanCutTiles()
         {

--- a/Content/Projectiles/JungleMimic/JungleMimicSummonCoin.cs
+++ b/Content/Projectiles/JungleMimic/JungleMimicSummonCoin.cs
@@ -31,7 +31,6 @@ namespace FargowiltasSouls.Content.Projectiles.JungleMimic
             Projectile.alpha = 255;
             Projectile.usesLocalNPCImmunity = true;
             Projectile.localNPCHitCooldown = 15;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override bool PreAI()

--- a/Content/Projectiles/LightningArc.cs
+++ b/Content/Projectiles/LightningArc.cs
@@ -40,7 +40,6 @@ namespace FargowiltasSouls.Content.Projectiles
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 20;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Projectiles/PhantasmalSphereRing.cs
+++ b/Content/Projectiles/PhantasmalSphereRing.cs
@@ -38,7 +38,6 @@ namespace FargowiltasSouls.Content.Projectiles
             Projectile.extraUpdates = 1;
 
             Projectile.FargoSouls().CanSplit = false;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Projectiles/Weapons/BossWeapons/DicerMine.cs
+++ b/Content/Projectiles/Weapons/BossWeapons/DicerMine.cs
@@ -24,7 +24,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.BossWeapons
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 15; // Similarly to Blender
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Projectiles/Weapons/BossWeapons/DicerSpray.cs
+++ b/Content/Projectiles/Weapons/BossWeapons/DicerSpray.cs
@@ -16,7 +16,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.BossWeapons
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 15; // Similarly to Blender
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
     }
 }

--- a/Content/Projectiles/Weapons/BossWeapons/DicerYoyo.cs
+++ b/Content/Projectiles/Weapons/BossWeapons/DicerYoyo.cs
@@ -39,7 +39,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.BossWeapons
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 15; // Similarly to Blender
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Projectiles/Weapons/BossWeapons/MechElectricOrbFriendly.cs
+++ b/Content/Projectiles/Weapons/BossWeapons/MechElectricOrbFriendly.cs
@@ -25,7 +25,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.BossWeapons
 
             Projectile.usesLocalNPCImmunity = true;
             Projectile.localNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
       /*public override void OnSpawn(IEntitySource source)

--- a/Content/Projectiles/Weapons/BossWeapons/Whirlpool.cs
+++ b/Content/Projectiles/Weapons/BossWeapons/Whirlpool.cs
@@ -34,7 +34,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.BossWeapons
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Projectiles/Weapons/ChallengerItems/TheLightning.cs
+++ b/Content/Projectiles/Weapons/ChallengerItems/TheLightning.cs
@@ -15,7 +15,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.ChallengerItems
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 20;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         float collideHeight;

--- a/Content/Projectiles/Weapons/FinalUpgrades/Penetrator.cs
+++ b/Content/Projectiles/Weapons/FinalUpgrades/Penetrator.cs
@@ -33,7 +33,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.FinalUpgrades
             Projectile.alpha = 0;
             Projectile.FargoSouls().CanSplit = false;
             Projectile.FargoSouls().TimeFreezeImmune = true;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override bool? Colliding(Rectangle projHitbox, Rectangle targetHitbox)

--- a/Content/Projectiles/Weapons/FinalUpgrades/PenetratorSword.cs
+++ b/Content/Projectiles/Weapons/FinalUpgrades/PenetratorSword.cs
@@ -35,7 +35,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.FinalUpgrades
             Projectile.alpha = 0;
             Projectile.FargoSouls().CanSplit = false;
             Projectile.FargoSouls().TimeFreezeImmune = true;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
 
             Projectile.timeLeft = MAXTIME;
         }

--- a/Content/Projectiles/Weapons/FinalUpgrades/PenetratorThrown.cs
+++ b/Content/Projectiles/Weapons/FinalUpgrades/PenetratorThrown.cs
@@ -36,7 +36,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.FinalUpgrades
             Projectile.extraUpdates = 1;
             Projectile.alpha = 0;
             Projectile.DamageType = DamageClass.Ranged;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
             Projectile.FargoSouls().DeletionImmuneRank = 2;
         }
 

--- a/Content/Projectiles/Weapons/FinalUpgrades/SparklingLoveBig.cs
+++ b/Content/Projectiles/Weapons/FinalUpgrades/SparklingLoveBig.cs
@@ -36,7 +36,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.FinalUpgrades
             Projectile.scale = 4f;
             Projectile.penetrate = -1;
             Projectile.FargoSouls().CanSplit = false;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
             Projectile.FargoSouls().DeletionImmuneRank = 2;
         }
 

--- a/Content/Projectiles/Weapons/FinalUpgrades/StyxGazer.cs
+++ b/Content/Projectiles/Weapons/FinalUpgrades/StyxGazer.cs
@@ -30,7 +30,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.FinalUpgrades
             Projectile.extraUpdates = 1;
             Projectile.FargoSouls().CanSplit = false;
             Projectile.FargoSouls().TimeFreezeImmune = true;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
             Projectile.FargoSouls().DeletionImmuneRank = 2;
         }
 

--- a/Content/Projectiles/Weapons/FinalUpgrades/StyxSickle.cs
+++ b/Content/Projectiles/Weapons/FinalUpgrades/StyxSickle.cs
@@ -40,8 +40,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.FinalUpgrades
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 1;
-
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void DrawBehind(int index, List<int> behindNPCsAndTiles, List<int> behindNPCs, List<int> behindProjectiles, List<int> overPlayers, List<int> overWiresUI)

--- a/Content/Projectiles/Weapons/Minions/AbomMinionSickle.cs
+++ b/Content/Projectiles/Weapons/Minions/AbomMinionSickle.cs
@@ -29,7 +29,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.Minions
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 5;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
 
             CooldownSlot = ImmunityCooldownID.General;
         }

--- a/Content/Projectiles/Weapons/Minions/DestroyerBody.cs
+++ b/Content/Projectiles/Weapons/Minions/DestroyerBody.cs
@@ -36,7 +36,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.Minions
             Projectile.hide = true;
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
             Projectile.FargoSouls().CanSplit = false;
         }
 

--- a/Content/Projectiles/Weapons/Minions/DestroyerBody2.cs
+++ b/Content/Projectiles/Weapons/Minions/DestroyerBody2.cs
@@ -38,7 +38,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.Minions
             Projectile.hide = true;
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
             Projectile.FargoSouls().CanSplit = false;
         }
 

--- a/Content/Projectiles/Weapons/Minions/DestroyerBodyWhip.cs
+++ b/Content/Projectiles/Weapons/Minions/DestroyerBodyWhip.cs
@@ -38,7 +38,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.Minions
             Projectile.hide = true;
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
             Projectile.FargoSouls().CanSplit = false;
         }
 

--- a/Content/Projectiles/Weapons/Minions/DestroyerHead.cs
+++ b/Content/Projectiles/Weapons/Minions/DestroyerHead.cs
@@ -38,7 +38,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.Minions
             Projectile.netImportant = true;
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
             Projectile.FargoSouls().CanSplit = false;
         }
 

--- a/Content/Projectiles/Weapons/Minions/DestroyerHead2.cs
+++ b/Content/Projectiles/Weapons/Minions/DestroyerHead2.cs
@@ -40,7 +40,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.Minions
             Projectile.netImportant = true;
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
             Projectile.FargoSouls().CanSplit = false;
         }
 

--- a/Content/Projectiles/Weapons/Minions/DestroyerHeadWhip.cs
+++ b/Content/Projectiles/Weapons/Minions/DestroyerHeadWhip.cs
@@ -40,7 +40,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.Minions
             Projectile.netImportant = true;
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
             Projectile.FargoSouls().CanSplit = false;
         }
 

--- a/Content/Projectiles/Weapons/Minions/DestroyerTail.cs
+++ b/Content/Projectiles/Weapons/Minions/DestroyerTail.cs
@@ -33,7 +33,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.Minions
             Projectile.hide = true;
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
             Projectile.FargoSouls().CanSplit = false;
         }
 

--- a/Content/Projectiles/Weapons/Minions/DestroyerTail2.cs
+++ b/Content/Projectiles/Weapons/Minions/DestroyerTail2.cs
@@ -34,7 +34,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.Minions
             Projectile.hide = true;
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
             Projectile.FargoSouls().CanSplit = false;
         }
 

--- a/Content/Projectiles/Weapons/Minions/DestroyerTailWhip.cs
+++ b/Content/Projectiles/Weapons/Minions/DestroyerTailWhip.cs
@@ -35,7 +35,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.Minions
             Projectile.hide = true;
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
             Projectile.FargoSouls().CanSplit = false;
         }
 

--- a/Content/Projectiles/Weapons/Minions/EaterBody.cs
+++ b/Content/Projectiles/Weapons/Minions/EaterBody.cs
@@ -36,7 +36,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.Minions
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 25;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void SendExtraAI(BinaryWriter writer)

--- a/Content/Projectiles/Weapons/Minions/EaterHead.cs
+++ b/Content/Projectiles/Weapons/Minions/EaterHead.cs
@@ -35,7 +35,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.Minions
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 25;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void SendExtraAI(BinaryWriter writer)

--- a/Content/Projectiles/Weapons/Minions/EaterTail.cs
+++ b/Content/Projectiles/Weapons/Minions/EaterTail.cs
@@ -35,7 +35,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.Minions
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 25;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void SendExtraAI(BinaryWriter writer)

--- a/Content/Projectiles/Weapons/Minions/LunarCultistIceSpike.cs
+++ b/Content/Projectiles/Weapons/Minions/LunarCultistIceSpike.cs
@@ -31,7 +31,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.Minions
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
 
             FargowiltasSouls.MutantMod.Call("LowRenderProj", Projectile);
         }

--- a/Content/Projectiles/Weapons/Minions/LunarCultistLightningArc.cs
+++ b/Content/Projectiles/Weapons/Minions/LunarCultistLightningArc.cs
@@ -40,7 +40,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.Minions
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Projectiles/Weapons/Minions/MechElectricOrbHomingFriendly.cs
+++ b/Content/Projectiles/Weapons/Minions/MechElectricOrbHomingFriendly.cs
@@ -28,7 +28,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.Minions
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 6;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Projectiles/Weapons/Minions/PhantasmalDeathrayPungent.cs
+++ b/Content/Projectiles/Weapons/Minions/PhantasmalDeathrayPungent.cs
@@ -40,7 +40,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.Minions
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 6;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Projectiles/Weapons/Minions/PhantasmalDeathrayTrueEye.cs
+++ b/Content/Projectiles/Weapons/Minions/PhantasmalDeathrayTrueEye.cs
@@ -32,7 +32,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.Minions
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 6;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Projectiles/Weapons/Minions/PhantasmalSphereTrueEye.cs
+++ b/Content/Projectiles/Weapons/Minions/PhantasmalSphereTrueEye.cs
@@ -35,7 +35,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.Minions
             Projectile.timeLeft = 300;
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 20;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Projectiles/Weapons/Minions/RingDeathray.cs
+++ b/Content/Projectiles/Weapons/Minions/RingDeathray.cs
@@ -35,7 +35,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.Minions
             Projectile.idStaticNPCHitCooldown = 10;
 
             Projectile.FargoSouls().CanSplit = false;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Projectiles/Weapons/SwarmDrops/BlenderOrbital.cs
+++ b/Content/Projectiles/Weapons/SwarmDrops/BlenderOrbital.cs
@@ -40,7 +40,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.SwarmDrops
 
             Projectile.FargoSouls().TimeFreezeImmune = true;
             Projectile.FargoSouls().DeletionImmuneRank = 2;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void SendExtraAI(BinaryWriter writer)

--- a/Content/Projectiles/Weapons/SwarmDrops/BlenderYoyoProj.cs
+++ b/Content/Projectiles/Weapons/SwarmDrops/BlenderYoyoProj.cs
@@ -44,7 +44,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.SwarmDrops
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 15;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         int soundtimer;

--- a/Content/Projectiles/Weapons/SwarmDrops/HellBone.cs
+++ b/Content/Projectiles/Weapons/SwarmDrops/HellBone.cs
@@ -32,7 +32,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.SwarmDrops
             
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 8;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
             Projectile.GetGlobalProjectile<AttackSpeedScalingGlobalProjectile>().UseAttackSpeedToDoubleHit = true;
         }
 

--- a/Content/Projectiles/Weapons/SwarmDrops/HellBonez.cs
+++ b/Content/Projectiles/Weapons/SwarmDrops/HellBonez.cs
@@ -32,7 +32,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.SwarmDrops
             
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 8;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
             Projectile.GetGlobalProjectile<AttackSpeedScalingGlobalProjectile>().UseAttackSpeedToDoubleHit = true;
         }
 

--- a/Content/Projectiles/Weapons/SwarmDrops/HellGuardian.cs
+++ b/Content/Projectiles/Weapons/SwarmDrops/HellGuardian.cs
@@ -33,7 +33,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.SwarmDrops
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 30;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Projectiles/Weapons/SwarmDrops/HellSkeletron.cs
+++ b/Content/Projectiles/Weapons/SwarmDrops/HellSkeletron.cs
@@ -34,7 +34,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.SwarmDrops
             
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 8;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Projectiles/Weapons/SwarmDrops/HellSkull2.cs
+++ b/Content/Projectiles/Weapons/SwarmDrops/HellSkull2.cs
@@ -41,7 +41,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.SwarmDrops
             
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 8;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Projectiles/Weapons/SwarmDrops/LeashofCthulhuEyeProjectile.cs
+++ b/Content/Projectiles/Weapons/SwarmDrops/LeashofCthulhuEyeProjectile.cs
@@ -34,7 +34,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.SwarmDrops
 
             Projectile.usesLocalNPCImmunity = true;
             Projectile.localNPCHitCooldown = 30;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
             Projectile.extraUpdates = 1;
         }
 

--- a/Content/Projectiles/Weapons/SwarmDrops/PrimeDeathray.cs
+++ b/Content/Projectiles/Weapons/SwarmDrops/PrimeDeathray.cs
@@ -30,7 +30,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.SwarmDrops
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 6;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void DrawBehind(int index, List<int> behindNPCsAndTiles, List<int> behindNPCs, List<int> behindProjectiles, List<int> overPlayers, List<int> overWiresUI)

--- a/Content/Projectiles/Weapons/SwarmDrops/ReleasedLeashofCthulhu.cs
+++ b/Content/Projectiles/Weapons/SwarmDrops/ReleasedLeashofCthulhu.cs
@@ -59,7 +59,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons.SwarmDrops
 
             Projectile.usesLocalNPCImmunity = true;
             Projectile.localNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override void AI()

--- a/Content/Projectiles/Weapons/TopHatSquirrelLaser.cs
+++ b/Content/Projectiles/Weapons/TopHatSquirrelLaser.cs
@@ -18,7 +18,6 @@ namespace FargowiltasSouls.Content.Projectiles.Weapons
 
             Projectile.usesIDStaticNPCImmunity = true;
             Projectile.idStaticNPCHitCooldown = 10;
-            Projectile.FargoSouls().noInteractionWithNPCImmunityFrames = true;
         }
 
         public override Color? GetAlpha(Color lightColor)


### PR DESCRIPTION
Moved all SetDefaults tags to a singular global tagging check under OnSpawn in FargoSoulsGlobalProjectile. Currently is universal to anything that: Pierces and has local or static IFrames associated.