### PR TITLE
Fix EOW despawning in multiplayer

### DIFF
--- a/Content/Bosses/VanillaEternity/EaterofWorlds.cs
+++ b/Content/Bosses/VanillaEternity/EaterofWorlds.cs
@@ -247,6 +247,10 @@ namespace FargowiltasSouls.Content.Bosses.VanillaEternity
         {
             EModeGlobalNPC.eaterBoss = npc.whoAmI;
             FargoSoulsGlobalNPC.boss = npc.whoAmI;
+            if (!npc.HasValidTarget)
+            {
+                npc.TargetClosest(false);
+            }
 
             if (!npc.HasValidTarget || npc.Distance(Main.player[npc.target].Center) > 6000)
             {


### PR DESCRIPTION
Stops Eater of Worlds from despawning immediately after killing one player, even if there are other players alive somewhat nearby